### PR TITLE
feat/automate-custom-bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,61 @@ build-catalog:
 		--filter-by-os="linux/amd64" \
 		--from=registry.redhat.io/openshift4/ose-operator-registry:$(OCP_VERSION) \
 		--to=quay.io/3scaleops/olm-catalog:$(CATALOG_RELEASE)
+
+########################
+#### Bundle targets ####
+########################
+
+# find or download yq
+# download yq if necessary
+yq:
+ifeq (, $(shell command -v yq 2> /dev/null))
+	@GO111MODULE=off go get github.com/mikefarah/yq/v3
+YQ=$(GOBIN)/yq
+else
+YQ=$(shell command -v yq 2> /dev/null)
+endif
+
+REGISTRY = quay.io/3scaleops
+BUNDLE_CATALOG_DIR = olm-bundle-catalog
+BUNDLE_CATALOG_IMG = $(REGISTRY)/olm-catalog:bundle
+BASE_TMP_DIR = /tmp/3scaleops-olm-catalog
+PROJECT_NAME = $(notdir $(basename $(SOURCE_REPOSITORY)))
+TMP_DIR = $(BASE_TMP_DIR)/$(PROJECT_NAME)_$(PROJECT_VERSION)
+MANIFESTS_DST_DIR = $(BUNDLE_CATALOG_DIR)/$(PROJECT_NAME)/$(PROJECT_VERSION)
+BUNDLE_SUFFIX = threescale
+BUNDLE_IMG = $(REGISTRY)/$(PROJECT_NAME)-$(BUNDLE_SUFFIX)-bundle:$(PROJECT_VERSION)
+
+.PHONY: build-bundle-manifests
+# Example: make bundle-build SOURCE_REPOSITORY=https://github.com/3scale/marin3r.git PROJECT_VERSION=v0.7.0-alpha5
+bundle-manifests: clean
+	git clone --depth 1 --branch $(PROJECT_VERSION) $(SOURCE_REPOSITORY) $(TMP_DIR) 2> /dev/null
+	mkdir -p $(MANIFESTS_DST_DIR)
+	cp -a $(TMP_DIR)/bundle/* $(MANIFESTS_DST_DIR)
+	cp -a $(TMP_DIR)/bundle.Dockerfile $(MANIFESTS_DST_DIR)
+	sed -E -i 's@bundle/@@' $(MANIFESTS_DST_DIR)/bundle.Dockerfile
+	$(MAKE) $(PROJECT_NAME)-customize-bundle
+	$(MAKE) clean
+
+# Build the bundle image.
+.PHONY: bundle-build
+bundle-build:
+	test -f $(MANIFESTS_DST_DIR)/manifests/$(PROJECT_NAME).clusterserviceversion.yaml || $(MAKE) bundle-manifests
+	docker build -f $(MANIFESTS_DST_DIR)/bundle.Dockerfile -t $(BUNDLE_IMG) $(MANIFESTS_DST_DIR)
+
+bundle-push:
+	docker push $(BUNDLE_IMG)
+
+catalog-add:
+	opm index add \
+		--build-tool docker \
+		--mode replaces \
+		--bundles $(BUNDLE_IMG) \
+		--from-index $(BUNDLE_CATALOG_IMG) \
+		--tag $(BUNDLE_CATALOG_IMG)
+	docker push $(BUNDLE_CATALOG_IMG)
+
+clean:
+	rm -rf $(BASE_TMP_DIR)
+
+include marin3r.mk

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ bundle-manifests: clean
 	mkdir -p $(MANIFESTS_DST_DIR)
 	cp -a $(TMP_DIR)/bundle/* $(MANIFESTS_DST_DIR)
 	cp -a $(TMP_DIR)/bundle.Dockerfile $(MANIFESTS_DST_DIR)
-	sed -E -i 's@bundle/@@' $(MANIFESTS_DST_DIR)/bundle.Dockerfile
+	sed -E -i '' 's@bundle/@@' $(MANIFESTS_DST_DIR)/bundle.Dockerfile
 	$(MAKE) $(PROJECT_NAME)-customize-bundle
 	$(MAKE) clean
 

--- a/marin3r.mk
+++ b/marin3r.mk
@@ -1,0 +1,23 @@
+MARIN3R_CSV_FILE = $(MANIFESTS_DST_DIR)/manifests/marin3r.clusterserviceversion.yaml
+MARIN3R_VERSION = $(PROJECT_VERSION)
+
+marin3r-customize-bundle: yq
+	@echo "using BUNDLE_SUFFIX $(BUNDLE_SUFFIX)"
+	$(YQ) w --inplace $(MARIN3R_CSV_FILE) metadata.name marin3r-$(BUNDLE_SUFFIX).$(MARIN3R_VERSION)
+	$(YQ) w --inplace $(MARIN3R_CSV_FILE) spec.displayName "MARIN3R 3scale SaaS"
+	$(YQ) w --inplace $(MARIN3R_CSV_FILE) spec.provider.name $(BUNDLE_SUFFIX)
+	$(YQ) w --inplace $(MANIFESTS_DST_DIR)/metadata/annotations.yaml 'annotations."operators.operatorframework.io.bundle.package.v1"' marin3r-$(BUNDLE_SUFFIX)
+	sed -E -i 's/(operators\.operatorframework\.io\.bundle\.package\.v1=).+/\1marin3r-$(BUNDLE_SUFFIX)/' $(MANIFESTS_DST_DIR)/bundle.Dockerfile
+	# Modify "spec.replaces" if set
+	-REPLACES=$(shell $(YQ) r $(MARIN3R_CSV_FILE) spec.replaces) && [ "$$REPLACES" != "" ] && \
+		$(YQ) w --inplace $(MARIN3R_CSV_FILE) spec.replaces "$${REPLACES/marin3r/marin3r-$(BUNDLE_SUFFIX)}"
+
+# Example: make marin3r-bundle-build PROJECT_VERSION=v0.7.0-alpha5
+marin3r-bundle-build: export SOURCE_REPOSITORY = https://github.com/3scale/marin3r.git
+marin3r-bundle-build: bundle-build
+
+marin3r-bundle-push: export SOURCE_REPOSITORY = https://github.com/3scale/marin3r.git
+marin3r-bundle-push: bundle-push
+
+marin3r-catalog-add: export SOURCE_REPOSITORY = https://github.com/3scale/marin3r.git
+marin3r-catalog-add: marin3r-bundle-build marin3r-bundle-push catalog-add

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha5/bundle.Dockerfile
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha5/bundle.Dockerfile
@@ -1,0 +1,15 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=marin3r-threescale
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.1.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+COPY manifests /manifests/
+COPY metadata /metadata/
+COPY tests/scorecard /tests/scorecard/

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/marin3r-controller-manager_v1_serviceaccount.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/marin3r-controller-manager_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: marin3r-controller-manager

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/marin3r-metrics-reader_rbac.authorization.k8s.io_v1beta1_clusterrole.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/marin3r-metrics-reader_rbac.authorization.k8s.io_v1beta1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: marin3r-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/marin3r.3scale.net_envoybootstraps.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/marin3r.3scale.net_envoybootstraps.yaml
@@ -1,0 +1,105 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: envoybootstraps.marin3r.3scale.net
+spec:
+  group: marin3r.3scale.net
+  names:
+    kind: EnvoyBootstrap
+    listKind: EnvoyBootstrapList
+    plural: envoybootstraps
+    singular: envoybootstrap
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: EnvoyBootstrap is the Schema for the envoybootstraps API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: EnvoyBootstrapSpec defines the desired state of EnvoyBootstrap
+          properties:
+            clientCertificate:
+              description: ClientCertificate is a struct containing options for the certificate used to authenticate with the discovery service
+              properties:
+                directory:
+                  description: Directory defines the directory in the envoy container where the certificate will be mounted
+                  type: string
+                duration:
+                  description: The requested ‘duration’ (i.e. lifetime) of the Certificate
+                  type: string
+                secretName:
+                  description: The Secret where the certificate will be stored
+                  type: string
+              required:
+              - directory
+              - duration
+              - secretName
+              type: object
+            discoveryService:
+              description: DiscoveryService is the name of the DiscoveryService resource the envoy will be a client of
+              type: string
+            envoyStaticConfig:
+              description: EnvoyStaticConfig is a struct that controls options for the envoy's static config file
+              properties:
+                adminAccessLogPath:
+                  description: AdminAccessLogPath configures where the envoy's admin server logs are written to
+                  type: string
+                adminBindAddress:
+                  description: AdminBindAddress is where envoy's admin server binds to.
+                  type: string
+                configFile:
+                  description: ConfigFile is the path of envoy's bootstrap config file
+                  type: string
+                configMapNameV2:
+                  description: The ConfigMap where the envoy client v2 static config will be stored
+                  type: string
+                configMapNameV3:
+                  description: The ConfigMap where the envoy client v3 static config will be stored
+                  type: string
+                resourcesDir:
+                  description: ResourcesDir is the path where resource files are loaded from. It is used to load discovery messages directly from the filesystem, for example in order to be able to bootstrap certificates and support rotation when they are modified.
+                  type: string
+                rtdsLayerResourceName:
+                  description: RtdsLayerResourceName is the resource name that the envoy client will request when askikng the discovery service for Runtime resources.
+                  type: string
+              required:
+              - adminAccessLogPath
+              - adminBindAddress
+              - configFile
+              - configMapNameV2
+              - configMapNameV3
+              - resourcesDir
+              - rtdsLayerResourceName
+              type: object
+          required:
+          - clientCertificate
+          - discoveryService
+          - envoyStaticConfig
+          type: object
+        status:
+          description: EnvoyBootstrapStatus defines the observed state of EnvoyBootstrap
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/marin3r.3scale.net_envoyconfigrevisions.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/marin3r.3scale.net_envoyconfigrevisions.yaml
@@ -1,0 +1,240 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: envoyconfigrevisions.marin3r.3scale.net
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.nodeID
+    name: Node ID
+    type: string
+  - JSONPath: .spec.envoyAPI
+    name: Envoy API
+    type: string
+  - JSONPath: .spec.version
+    name: Version
+    type: string
+  - JSONPath: .status.published
+    name: Published
+    type: boolean
+  - JSONPath: .metadata.creationTimestamp
+    format: date-time
+    name: Created At
+    type: string
+  - JSONPath: .status.lastPublishedAt
+    format: date-time
+    name: Last Published At
+    type: string
+  - JSONPath: .status.tainted
+    name: Tainted
+    type: boolean
+  group: marin3r.3scale.net
+  names:
+    kind: EnvoyConfigRevision
+    listKind: EnvoyConfigRevisionList
+    plural: envoyconfigrevisions
+    shortNames:
+    - ecr
+    singular: envoyconfigrevision
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: EnvoyConfigRevision holds an specific version of the EnvoyConfig resources. EnvoyConfigRevisions are automatically created and deleted  by the EnvoyConfig controller and are not intended to be directly used. Use EnvoyConfig objects instead.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: EnvoyConfigRevisionSpec defines the desired state of EnvoyConfigRevision
+          properties:
+            envoyAPI:
+              description: EnvoyAPI is the version of envoy's API to use. Defaults to v2.
+              enum:
+              - v2
+              - v3
+              type: string
+            envoyResources:
+              description: EnvoyResources holds the different types of resources suported by the envoy discovery service
+              properties:
+                clusters:
+                  description: 'Clusters is a list of the envoy Cluster resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cluster.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                endpoints:
+                  description: 'Endpoints is a list of the envoy ClusterLoadAssignment resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/endpoint.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                listeners:
+                  description: 'Listeners is a list of the envoy Listener resource type. V2 referece: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                routes:
+                  description: 'Routes is a list of the envoy Route resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                runtime:
+                  description: 'Runtimes is a list of the envoy Runtime resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/discovery/v2/rtds.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/runtime/v3/rtds.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                secrets:
+                  description: Secrets is a list of references to Kubernetes Secret objects.
+                  items:
+                    description: EnvoySecretResource holds a reference to a k8s Secret from where to take a secret from
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      ref:
+                        description: Ref is a reference to a Kubernetes Secret of type "kubernetes.io/tls" from which an envoy Secret resource will be automatically created.
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which the secret name must be unique.
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    - ref
+                    type: object
+                  type: array
+              type: object
+            nodeID:
+              description: NodeID holds the envoy identifier for the discovery service to know which set of resources to send to each of the envoy clients that connect to it.
+              type: string
+            serialization:
+              description: Serialization specicifies the serialization format used to describe the resources. "json" and "yaml" are supported. "json" is used if unset.
+              enum:
+              - json
+              - b64json
+              - yaml
+              type: string
+            version:
+              description: Version is a hash of the EnvoyResources field
+              type: string
+          required:
+          - envoyResources
+          - nodeID
+          - version
+          type: object
+        status:
+          description: EnvoyConfigRevisionStatus defines the observed state of EnvoyConfigRevision
+          properties:
+            conditions:
+              description: Conditions represent the latest available observations of an object's state
+              items:
+                description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            lastPublishedAt:
+              description: LastPublishedAt indicates the last time this config review transitioned to published
+              format: date-time
+              type: string
+            published:
+              description: Published signals if the EnvoyConfigRevision is the one currently published in the xds server cache
+              type: boolean
+            tainted:
+              description: Tainted indicates whether the EnvoyConfigRevision is eligible for publishing or not
+              type: boolean
+          required:
+          - conditions
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/marin3r.3scale.net_envoyconfigs.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/marin3r.3scale.net_envoyconfigs.yaml
@@ -1,0 +1,263 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: envoyconfigs.marin3r.3scale.net
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.nodeID
+    name: Node ID
+    type: string
+  - JSONPath: .spec.envoyAPI
+    name: Envoy API
+    type: string
+  - JSONPath: .status.desiredVersion
+    name: Desired Version
+    type: string
+  - JSONPath: .status.publishedVersion
+    name: Published Version
+    type: string
+  - JSONPath: .status.cacheState
+    name: Cache State
+    type: string
+  group: marin3r.3scale.net
+  names:
+    kind: EnvoyConfig
+    listKind: EnvoyConfigList
+    plural: envoyconfigs
+    shortNames:
+    - ec
+    singular: envoyconfig
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: EnvoyConfig holds the configuration for a given envoy nodeID. The spec of an EnvoyConfig object holds the envoy resources that conform the desired configuration for the given nodeID and that the discovery service will send to any envoy client that identifies itself with that nodeID.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: EnvoyConfigSpec defines the desired state of EnvoyConfig
+          properties:
+            envoyAPI:
+              description: EnvoyAPI is the version of envoy's API to use. Defaults to v2.
+              enum:
+              - v2
+              - v3
+              type: string
+            envoyResources:
+              description: EnvoyResources holds the different types of resources suported by the envoy discovery service
+              properties:
+                clusters:
+                  description: 'Clusters is a list of the envoy Cluster resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cluster.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                endpoints:
+                  description: 'Endpoints is a list of the envoy ClusterLoadAssignment resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/endpoint.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                listeners:
+                  description: 'Listeners is a list of the envoy Listener resource type. V2 referece: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                routes:
+                  description: 'Routes is a list of the envoy Route resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                runtime:
+                  description: 'Runtimes is a list of the envoy Runtime resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/discovery/v2/rtds.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/runtime/v3/rtds.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                secrets:
+                  description: Secrets is a list of references to Kubernetes Secret objects.
+                  items:
+                    description: EnvoySecretResource holds a reference to a k8s Secret from where to take a secret from
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      ref:
+                        description: Ref is a reference to a Kubernetes Secret of type "kubernetes.io/tls" from which an envoy Secret resource will be automatically created.
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which the secret name must be unique.
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    - ref
+                    type: object
+                  type: array
+              type: object
+            nodeID:
+              description: NodeID holds the envoy identifier for the discovery service to know which set of resources to send to each of the envoy clients that connect to it.
+              type: string
+            serialization:
+              description: Serialization specicifies the serialization format used to describe the resources. "json" and "yaml" are supported. "json" is used if unset.
+              enum:
+              - json
+              - b64json
+              - yaml
+              type: string
+          required:
+          - envoyResources
+          - nodeID
+          type: object
+        status:
+          description: EnvoyConfigStatus defines the observed state of EnvoyConfig
+          properties:
+            cacheState:
+              description: CacheState summarizes all the observations about the EnvoyConfig to give the user a concrete idea on the general status of the discovery servie cache. It is intended only for human consumption. Other controllers should relly on conditions to determine the status of the discovery server cache.
+              type: string
+            conditions:
+              description: Conditions represent the latest available observations of an object's state
+              items:
+                description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            desiredVersion:
+              description: DesiredVersion represents the resources version described in the spec of the EnvoyConfig object
+              type: string
+            publishedVersion:
+              description: PublishedVersion is the config version currently served by the envoy discovery service for the give nodeID
+              type: string
+            revisions:
+              description: ConfigRevisions is an ordered list of references to EnvoyConfigRevision objects
+              items:
+                description: ConfigRevisionRef holds a reference to EnvoyConfigRevision object
+                properties:
+                  ref:
+                    description: Ref is a reference to the EnvoyConfigRevision object that holds the configuration matching the Version field.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  version:
+                    description: Version is a hash of the EnvoyResources field
+                    type: string
+                required:
+                - ref
+                - version
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/marin3r.clusterserviceversion.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/marin3r.clusterserviceversion.yaml
@@ -1,0 +1,798 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "marin3r.3scale.net/v1alpha1",
+          "kind": "EnvoyBootstrap",
+          "metadata": {
+            "name": "envoybootstrap-sample"
+          },
+          "spec": {
+            "clientCertificate": {
+              "directory": "/etc/envoy/tls/client",
+              "duration": "1h",
+              "secretName": "discoveryservice-client-certificate"
+            },
+            "discoveryService": "instance",
+            "envoyStaticConfig": {
+              "adminAccessLogPath": "/dev/null",
+              "adminBindAddress": "0.0.0.0:9901",
+              "configFile": "config.yaml",
+              "configMapNameV2": "envoy-bootstrap-v2",
+              "configMapNameV3": "envoy-bootstrap-v3",
+              "resourcesDir": "/etc/envoy/bootstrap",
+              "rtdsLayerResourceName": "runtime"
+            }
+          }
+        },
+        {
+          "apiVersion": "marin3r.3scale.net/v1alpha1",
+          "kind": "EnvoyConfig",
+          "metadata": {
+            "name": "example",
+            "namespace": "my-namespace"
+          },
+          "spec": {
+            "envoyResources": {
+              "clusters": [
+                {
+                  "name": "example",
+                  "value": "name: example\nconnect_timeout: 2s\ntype: STRICT_DNS\nlb_policy: ROUND_ROBIN\nload_assignment:\n  cluster_name: example\n  endpoints: []\n"
+                }
+              ],
+              "listeners": [
+                {
+                  "name": "http",
+                  "value": "name: http\naddress:\n  socket_address:\n    address: 0.0.0.0\n    port_value: 8080\nfilter_chains:\n- filters:\n  - name: envoy.http_connection_manager\n    typed_config:\n      \"@type\": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager\n      stat_prefix: ingress_http\n      route_config:\n        name: local_route\n        virtual_hosts:\n        - name: example\n          domains: [\"*\"]\n          routes:\n          - match:\n              prefix: \"/\"\n            route:\n              cluster: example\n      http_filters:\n      - name: envoy.router\n"
+                }
+              ],
+              "secrets": [
+                {
+                  "name": "example.com",
+                  "ref": {
+                    "name": "example-cert",
+                    "namespace": "my-namespace"
+                  }
+                }
+              ]
+            },
+            "nodeID": "example",
+            "serialization": "yaml"
+          }
+        },
+        {
+          "apiVersion": "marin3r.3scale.net/v1alpha1",
+          "kind": "EnvoyConfigRevision",
+          "metadata": {
+            "name": "example",
+            "namespace": "my-namespace"
+          },
+          "spec": {
+            "envoyResources": {
+              "clusters": [
+                {
+                  "name": "example",
+                  "value": "name: example\nconnect_timeout: 2s\ntype: STRICT_DNS\nlb_policy: ROUND_ROBIN\nload_assignment:\n  cluster_name: example\n  endpoints: []\n"
+                }
+              ],
+              "listeners": [
+                {
+                  "name": "http",
+                  "value": "name: http\naddress:\n  socket_address:\n    address: 0.0.0.0\n    port_value: 8080\nfilter_chains:\n- filters:\n  - name: envoy.http_connection_manager\n    typed_config:\n      \"@type\": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager\n      stat_prefix: ingress_http\n      route_config:\n        name: local_route\n        virtual_hosts:\n        - name: example\n          domains: [\"*\"]\n          routes:\n          - match:\n              prefix: \"/\"\n            route:\n              cluster: example\n      http_filters:\n      - name: envoy.router\n"
+                }
+              ],
+              "secrets": [
+                {
+                  "name": "example.com",
+                  "ref": {
+                    "name": "example-cert",
+                    "namespace": "my-namespace"
+                  }
+                }
+              ]
+            },
+            "nodeID": "example",
+            "serialization": "yaml",
+            "version": "hash"
+          }
+        },
+        {
+          "apiVersion": "operator.marin3r.3scale.net/v1alpha1",
+          "kind": "DiscoveryService",
+          "metadata": {
+            "name": "instance"
+          },
+          "spec": {
+            "debug": true,
+            "discoveryServiceNamespace": "default",
+            "enabledNamespaces": [
+              "test1",
+              "test2"
+            ],
+            "image": "quay.io/3scale/marin3r:latest"
+          }
+        },
+        {
+          "apiVersion": "operator.marin3r.3scale.net/v1alpha1",
+          "kind": "DiscoveryServiceCertificate",
+          "metadata": {
+            "name": "test-cert",
+            "namespace": "default"
+          },
+          "spec": {
+            "commonName": "test-client",
+            "secretRef": {
+              "name": "test-cert",
+              "namespace": "default"
+            },
+            "signer": {
+              "certManager": {
+                "clusterIssuer": "marin3r-instance"
+              }
+            },
+            "validFor": 3600
+          }
+        }
+      ]
+    capabilities: Basic Install
+    certified: "false"
+    containerImage: quay.io/3scale/marin3r
+    description: Manage an Envoy Discovery Service and a fleet of Envoy proxies.
+    operators.operatorframework.io/builder: operator-sdk-v1.1.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+    repository: https://github.com/3scale/marin3r
+    support: Red Hat, Inc.
+  name: marin3r-threescale.v0.7.0-alpha5
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: DiscoveryServiceCertificate is used to create certificates, either self-signed or by using a cert-manager CA issuer. This object is used by the DiscoveryService controller to create the required certificates for the different components of the discovery service. Direct use of DiscoveryServiceCertificate objects is discouraged.
+        displayName: DiscoveryServiceCertificate
+        kind: DiscoveryServiceCertificate
+        name: discoveryservicecertificates.operator.marin3r.3scale.net
+        specDescriptors:
+          - description: CertificateRenewalConfig configures the certificate renewal process. If unset default behavior is to renew the certificate but not notify of renewals.
+            displayName: Certificate Renewal Config
+            path: certificateRenewalNotification
+          - description: Enabled is a flag to enable or disable renewal of the certificate
+            displayName: Enabled
+            path: certificateRenewalNotification.enabled
+          - description: CommonName is the CommonName of the certificate
+            displayName: Common Name
+            path: commonName
+          - description: Hosts is the list of hosts the certificate is valid for. Only use when 'IsServerCertificate' is true. If unset, the CommonName field will be used to populate the valid hosts of the certificate.
+            displayName: Hosts
+            path: hosts
+          - description: IsCA is a boolean specifying that the certificate is a CA
+            displayName: Is CA
+            path: isCA
+          - description: SecretRef is a reference to the secret that will hold the certificate and the private key.
+            displayName: Secret Ref
+            path: secretRef
+          - description: IsServerCertificate is a boolean specifying if the certificate should be issued with server auth usage enabled
+            displayName: Is Server Certificate
+            path: server
+          - description: Signer specifies  the signer to use to create this certificate. Supported signers are CertManager and SelfSigned.
+            displayName: Signer
+            path: signer
+          - description: CASigned holds specific configuration for the CASigned signer
+            displayName: CASigned
+            path: signer.caSigned
+          - description: A reference to a Secret containing the CA
+            displayName: Secret Ref
+            path: signer.caSigned.caSecretRef
+          - description: SelfSigned holds specific configuration for the SelfSigned signer
+            displayName: Self Signed
+            path: signer.selfSigned
+          - description: ValidFor specifies the validity of the certificate in seconds
+            displayName: Valid For
+            path: validFor
+        statusDescriptors:
+          - description: Conditions represent the latest available observations of an object's state
+            displayName: Conditions
+            path: conditions
+        version: v1alpha1
+      - description: DiscoveryService represents an envoy discovery service server. Currently only one DiscoveryService per cluster is supported.
+        displayName: DiscoveryService
+        kind: DiscoveryService
+        name: discoveryservices.operator.marin3r.3scale.net
+        specDescriptors:
+          - description: ServiceConfig configures the way the DiscoveryService endpoints are exposed
+            displayName: Service Config
+            path: ServiceConfig
+          - displayName: Name
+            path: ServiceConfig.name
+          - displayName: Type
+            path: ServiceConfig.type
+          - description: Debug enables debugging log level for the discovery service controllers. It is safe to use since secret data is never shown in the logs.
+            displayName: Debug
+            path: debug
+          - description: Image holds the image to use for the discovery service Deployment
+            displayName: Image
+            path: image
+          - description: MetricsPort is the port where metrics are served. Defaults to 8383.
+            displayName: Metrics Port
+            path: metricsPort
+          - description: PKIConfig has configuration for the PKI that marin3r manages for the different certificates it requires
+            displayName: PKIConfig
+            path: pkiConfg
+          - displayName: Root Certificate Authority
+            path: pkiConfg.rootCertificateAuthority
+          - displayName: Duration
+            path: pkiConfg.rootCertificateAuthority.duration
+          - displayName: Secret Name
+            path: pkiConfg.rootCertificateAuthority.secretName
+          - displayName: Server Certificate
+            path: pkiConfg.serverCertificate
+          - displayName: Duration
+            path: pkiConfg.serverCertificate.duration
+          - displayName: Secret Name
+            path: pkiConfg.serverCertificate.secretName
+          - description: Resources holds the Resource Requirements to use for the discovery service Deployment. When not set it defaults to no resource requests nor limits. CPU and Memory resources are supported.
+            displayName: Resources
+            path: resources
+          - description: XdsServerPort is the port where the xDS server listens. Defaults to 18000.
+            displayName: Xds Server Port
+            path: xdsPort
+        statusDescriptors:
+          - description: Conditions represent the latest available observations of an object's state
+            displayName: Conditions
+            path: conditions
+        version: v1alpha1
+      - description: EnvoyBootstrap is the Schema for the envoybootstraps API
+        displayName: EnvoyBootstrap
+        kind: EnvoyBootstrap
+        name: envoybootstraps.marin3r.3scale.net
+        specDescriptors:
+          - description: ClientCertificate is a struct containing options for the certificate used to authenticate with the discovery service
+            displayName: Client Certificate
+            path: clientCertificate
+          - description: Directory defines the directory in the envoy container where the certificate will be mounted
+            displayName: Directory
+            path: clientCertificate.directory
+          - description: The requested ‘duration’ (i.e. lifetime) of the Certificate
+            displayName: Duration
+            path: clientCertificate.duration
+          - description: The Secret where the certificate will be stored
+            displayName: Secret Name
+            path: clientCertificate.secretName
+          - description: DiscoveryService is the name of the DiscoveryService resource the envoy will be a client of
+            displayName: Discovery Service
+            path: discoveryService
+          - description: EnvoyStaticConfig is a struct that controls options for the envoy's static config file
+            displayName: Envoy Static Config
+            path: envoyStaticConfig
+          - description: AdminAccessLogPath configures where the envoy's admin server logs are written to
+            displayName: Admin Access Log Path
+            path: envoyStaticConfig.adminAccessLogPath
+          - description: AdminBindAddress is where envoy's admin server binds to.
+            displayName: Admin Bind Address
+            path: envoyStaticConfig.adminBindAddress
+          - description: ConfigFile is the path of envoy's bootstrap config file
+            displayName: Config File
+            path: envoyStaticConfig.configFile
+          - description: The ConfigMap where the envoy client v2 static config will be stored
+            displayName: Config Map Name V2
+            path: envoyStaticConfig.configMapNameV2
+          - description: The ConfigMap where the envoy client v3 static config will be stored
+            displayName: Config Map Name V3
+            path: envoyStaticConfig.configMapNameV3
+          - description: ResourcesDir is the path where resource files are loaded from. It is used to load discovery messages directly from the filesystem, for example in order to be able to bootstrap certificates and support rotation when they are modified.
+            displayName: Resources Dir
+            path: envoyStaticConfig.resourcesDir
+          - description: RtdsLayerResourceName is the resource name that the envoy client will request when askikng the discovery service for Runtime resources.
+            displayName: Rtds Layer Resource Name
+            path: envoyStaticConfig.rtdsLayerResourceName
+        version: v1alpha1
+      - description: EnvoyConfigRevision holds an specific version of the EnvoyConfig resources. EnvoyConfigRevisions are automatically created and deleted  by the EnvoyConfig controller and are not intended to be directly used. Use EnvoyConfig objects instead.
+        displayName: EnvoyConfigRevision
+        kind: EnvoyConfigRevision
+        name: envoyconfigrevisions.marin3r.3scale.net
+        specDescriptors:
+          - description: EnvoyAPI is the version of envoy's API to use. Defaults to v2.
+            displayName: Envoy API
+            path: envoyAPI
+          - description: EnvoyResources holds the different types of resources suported by the envoy discovery service
+            displayName: Envoy Resources
+            path: envoyResources
+          - description: NodeID holds the envoy identifier for the discovery service to know which set of resources to send to each of the envoy clients that connect to it.
+            displayName: Node ID
+            path: nodeID
+          - description: Serialization specicifies the serialization format used to describe the resources. "json" and "yaml" are supported. "json" is used if unset.
+            displayName: Serialization
+            path: serialization
+          - description: Version is a hash of the EnvoyResources field
+            displayName: Version
+            path: version
+        statusDescriptors:
+          - description: Conditions represent the latest available observations of an object's state
+            displayName: Conditions
+            path: conditions
+          - description: LastPublishedAt indicates the last time this config review transitioned to published
+            displayName: Last Published At
+            path: lastPublishedAt
+          - description: Published signals if the EnvoyConfigRevision is the one currently published in the xds server cache
+            displayName: Published
+            path: published
+          - description: Tainted indicates whether the EnvoyConfigRevision is eligible for publishing or not
+            displayName: Tainted
+            path: tainted
+        version: v1alpha1
+      - description: EnvoyConfig holds the configuration for a given envoy nodeID. The spec of an EnvoyConfig object holds the envoy resources that conform the desired configuration for the given nodeID and that the discovery service will send to any envoy client that identifies itself with that nodeID.
+        displayName: EnvoyConfig
+        kind: EnvoyConfig
+        name: envoyconfigs.marin3r.3scale.net
+        resources:
+          - kind: EnvoyConfigRevision
+            name: ""
+            version: v1alpha1
+        specDescriptors:
+          - description: EnvoyAPI is the version of envoy's API to use. Defaults to v2.
+            displayName: Envoy API
+            path: envoyAPI
+          - description: EnvoyResources holds the different types of resources suported by the envoy discovery service
+            displayName: Envoy Resources
+            path: envoyResources
+          - description: 'Clusters is a list of the envoy Cluster resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cluster.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto'
+            displayName: Clusters
+            path: envoyResources.clusters
+          - description: Name of the envoy resource
+            displayName: Name
+            path: envoyResources.clusters[0].name
+          - description: Value is the serialized representation of the envoy resource
+            displayName: Value
+            path: envoyResources.clusters[0].value
+          - description: 'Endpoints is a list of the envoy ClusterLoadAssignment resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/endpoint.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint.proto'
+            displayName: Endpoints
+            path: envoyResources.endpoints
+          - description: Name of the envoy resource
+            displayName: Name
+            path: envoyResources.endpoints[0].name
+          - description: Value is the serialized representation of the envoy resource
+            displayName: Value
+            path: envoyResources.endpoints[0].value
+          - description: 'Listeners is a list of the envoy Listener resource type. V2 referece: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto'
+            displayName: Listeners
+            path: envoyResources.listeners
+          - description: Name of the envoy resource
+            displayName: Name
+            path: envoyResources.listeners[0].name
+          - description: Value is the serialized representation of the envoy resource
+            displayName: Value
+            path: envoyResources.listeners[0].value
+          - description: 'Routes is a list of the envoy Route resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto'
+            displayName: Routes
+            path: envoyResources.routes
+          - description: Name of the envoy resource
+            displayName: Name
+            path: envoyResources.routes[0].name
+          - description: Value is the serialized representation of the envoy resource
+            displayName: Value
+            path: envoyResources.routes[0].value
+          - description: 'Runtimes is a list of the envoy Runtime resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/discovery/v2/rtds.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/runtime/v3/rtds.proto'
+            displayName: Runtimes
+            path: envoyResources.runtime
+          - description: Name of the envoy resource
+            displayName: Name
+            path: envoyResources.runtime[0].name
+          - description: Value is the serialized representation of the envoy resource
+            displayName: Value
+            path: envoyResources.runtime[0].value
+          - description: Secrets is a list of references to Kubernetes Secret objects.
+            displayName: Secrets
+            path: envoyResources.secrets
+          - description: Name of the envoy resource
+            displayName: Name
+            path: envoyResources.secrets[0].name
+          - description: Ref is a reference to a Kubernetes Secret of type "kubernetes.io/tls" from which an envoy Secret resource will be automatically created.
+            displayName: Ref
+            path: envoyResources.secrets[0].ref
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:SecretReference
+          - description: NodeID holds the envoy identifier for the discovery service to know which set of resources to send to each of the envoy clients that connect to it.
+            displayName: Node ID
+            path: nodeID
+          - description: Serialization specicifies the serialization format used to describe the resources. "json" and "yaml" are supported. "json" is used if unset.
+            displayName: Serialization
+            path: serialization
+        statusDescriptors:
+          - description: CacheState summarizes all the observations about the EnvoyConfig to give the user a concrete idea on the general status of the discovery servie cache. It is intended only for human consumption. Other controllers should relly on conditions to determine the status of the discovery server cache.
+            displayName: Cache State
+            path: cacheState
+          - description: Conditions represent the latest available observations of an object's state
+            displayName: Conditions
+            path: conditions
+          - description: DesiredVersion represents the resources version described in the spec of the EnvoyConfig object
+            displayName: Desired Version
+            path: desiredVersion
+          - description: PublishedVersion is the config version currently served by the envoy discovery service for the give nodeID
+            displayName: Published Version
+            path: publishedVersion
+          - description: ConfigRevisions is an ordered list of references to EnvoyConfigRevision objects
+            displayName: Config Revisions
+            path: revisions
+          - description: Ref is a reference to the EnvoyConfigRevision object that holds the configuration matching the Version field.
+            displayName: Ref
+            path: revisions[0].ref
+          - description: Version is a hash of the EnvoyResources field
+            displayName: Version
+            path: revisions[0].version
+        version: v1alpha1
+  description: |
+    Marin3r is an operator to manage an Envoy discovery service and a fleet of Envoy proxies that
+    connect to it to fetch their configurations dynamically. It's main purpose is to provide
+    an easy way to deploy a discovery service with the basic functionality already in place so you
+    can focus on developing your Envoy configurationss or even your own domain specifig CRDs leveraging
+    the ones that Marin3r provides.
+
+
+    ## Managed installation (kind DiscoveryService)
+
+    * Basic installation and setup of an Envoy discovery service
+    * Automatic deployment of a kubernetes mutating admission webhook to inject Envoy sidecars in your pods
+    * Automatic configuration of Envoy sidecars to find the discovery service within the cluster
+    * Mututal TLS authentication between Envoy sidecars and the discovery service
+    * The discovery service and the Envoy proxies that conenct to it must live in the same namespace
+
+    ## Deploy Envoy configurations as kubernetes custom resources (kind EnvoyConfig)
+
+    * Each EnvoyConfig object holds Envoy resources that will be "pushed" to the appropriate set of pods
+    * Control which config goes to which pod directly using annotations on the pod
+    * The whole Envoy v2 API is supported
+    * Envoy resources can be both expressed as json or yaml
+    * A history of the last 10 configurations is kept per EnvoyConfig object
+    * Self-healing is attempted when the Envoy sidecars are not able to load the resources defined in the
+      EnvoyConfig by rolling back to a previous working config version
+
+    ## License
+    marin3r is licensed under the [Apache 2.0 license](https://github.com/3scale/prometheus-exporter-operator/blob/master/LICENSE)
+  displayName: MARIN3R 3scale SaaS
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMzc1cHQiIGhlaWdodD0iMzc0Ljk5OTk5MXB0IiB2aWV3Qm94PSIwIDAgMzc1IDM3NC45OTk5OTEiIHZlcnNpb249IjEuMiI+CjxkZWZzPgo8Zz4KPHN5bWJvbCBvdmVyZmxvdz0idmlzaWJsZSIgaWQ9ImdseXBoMC0wIj4KPHBhdGggc3R5bGU9InN0cm9rZTpub25lOyIgZD0iIi8+Cjwvc3ltYm9sPgo8c3ltYm9sIG92ZXJmbG93PSJ2aXNpYmxlIiBpZD0iZ2x5cGgwLTEiPgo8cGF0aCBzdHlsZT0ic3Ryb2tlOm5vbmU7IiBkPSJNIDQ1LjIwMzEyNSAwIEwgNDEuNTMxMjUgMCBMIDQxLjUzMTI1IC0yMi4wMzEyNSBMIDI1LjYwOTM3NSAwIEwgMjMuNzE4NzUgMCBMIDcuNzgxMjUgLTIyLjAzMTI1IEwgNy43ODEyNSAwIEwgNC4xMDkzNzUgMCBMIDQuMTA5Mzc1IC0yOS41MTU2MjUgTCA2Ljg3NSAtMjkuNTE1NjI1IEwgMjQuNjU2MjUgLTQuOTM3NSBMIDQyLjQyMTg3NSAtMjkuNTE1NjI1IEwgNDUuMjAzMTI1IC0yOS41MTU2MjUgWiBNIDQ1LjIwMzEyNSAwICIvPgo8L3N5bWJvbD4KPHN5bWJvbCBvdmVyZmxvdz0idmlzaWJsZSIgaWQ9ImdseXBoMC0yIj4KPHBhdGggc3R5bGU9InN0cm9rZTpub25lOyIgZD0iTSA0Mi40Njg3NSAwIEwgMzguMDQ2ODc1IDAgTCAzMy41MzEyNSAtNi42NzE4NzUgTCA5LjUzMTI1IC02LjY3MTg3NSBMIDUuMDQ2ODc1IDAgTCAwLjYyNSAwIEwgMjAuNTYyNSAtMjkuNTE1NjI1IEwgMjIuNSAtMjkuNTE1NjI1IFogTSAzMS4wNjI1IC0xMC4zMjgxMjUgTCAyMS41MzEyNSAtMjQuNDA2MjUgTCAxMi4wMTU2MjUgLTEwLjMyODEyNSBaIE0gMzEuMDYyNSAtMTAuMzI4MTI1ICIvPgo8L3N5bWJvbD4KPHN5bWJvbCBvdmVyZmxvdz0idmlzaWJsZSIgaWQ9ImdseXBoMC0zIj4KPHBhdGggc3R5bGU9InN0cm9rZTpub25lOyIgZD0iTSAzOS41MTU2MjUgMCBMIDM1Ljg1OTM3NSAwIEwgMzUuODU5Mzc1IC04LjA0Njg3NSBDIDM1Ljg1OTM3NSAtOC44Nzg5MDYgMzUuNTU0Njg4IC05LjU5Mzc1IDM0Ljk1MzEyNSAtMTAuMTg3NSBDIDM0LjM1OTM3NSAtMTAuNzg5MDYyIDMzLjY0NDUzMSAtMTEuMDkzNzUgMzIuODEyNSAtMTEuMDkzNzUgTCA3Ljc4MTI1IC0xMS4wOTM3NSBMIDcuNzgxMjUgMCBMIDQuMTA5Mzc1IDAgTCA0LjEwOTM3NSAtMjkuNTE1NjI1IEwgMzIuODEyNSAtMjkuNTE1NjI1IEMgMzQuNjY0MDYyIC0yOS41MTU2MjUgMzYuMjQyMTg4IC0yOC44NTkzNzUgMzcuNTQ2ODc1IC0yNy41NDY4NzUgQyAzOC44NTkzNzUgLTI2LjI0MjE4OCAzOS41MTU2MjUgLTI0LjY2NDA2MiAzOS41MTU2MjUgLTIyLjgxMjUgTCAzOS41MTU2MjUgLTE3LjgxMjUgQyAzOS41MTU2MjUgLTE1Ljg4MjgxMiAzOC44MTY0MDYgLTE0LjI1MzkwNiAzNy40MjE4NzUgLTEyLjkyMTg3NSBDIDM4LjgxNjQwNiAtMTEuNTk3NjU2IDM5LjUxNTYyNSAtOS45NzI2NTYgMzkuNTE1NjI1IC04LjA0Njg3NSBaIE0gMzIuODEyNSAtMTQuNzY1NjI1IEMgMzMuNjQ0NTMxIC0xNC43NjU2MjUgMzQuMzU5Mzc1IC0xNS4wNjI1IDM0Ljk1MzEyNSAtMTUuNjU2MjUgQyAzNS41NTQ2ODggLTE2LjI1IDM1Ljg1OTM3NSAtMTYuOTY4NzUgMzUuODU5Mzc1IC0xNy44MTI1IEwgMzUuODU5Mzc1IC0yMi44MTI1IEMgMzUuODU5Mzc1IC0yMy42NDQ1MzEgMzUuNTU0Njg4IC0yNC4zNTkzNzUgMzQuOTUzMTI1IC0yNC45NTMxMjUgQyAzNC4zNTkzNzUgLTI1LjU1NDY4OCAzMy42NDQ1MzEgLTI1Ljg1OTM3NSAzMi44MTI1IC0yNS44NTkzNzUgTCA3Ljc4MTI1IC0yNS44NTkzNzUgTCA3Ljc4MTI1IC0xNC43NjU2MjUgWiBNIDMyLjgxMjUgLTE0Ljc2NTYyNSAiLz4KPC9zeW1ib2w+CjxzeW1ib2wgb3ZlcmZsb3c9InZpc2libGUiIGlkPSJnbHlwaDAtNCI+CjxwYXRoIHN0eWxlPSJzdHJva2U6bm9uZTsiIGQ9Ik0gNy43ODEyNSAwIEwgNy43ODEyNSAtMjkuNTE1NjI1IEwgNC4xMDkzNzUgLTI5LjUxNTYyNSBMIDQuMTA5Mzc1IDAgWiBNIDcuNzgxMjUgMCAiLz4KPC9zeW1ib2w+CjxzeW1ib2wgb3ZlcmZsb3c9InZpc2libGUiIGlkPSJnbHlwaDAtNSI+CjxwYXRoIHN0eWxlPSJzdHJva2U6bm9uZTsiIGQ9Ik0gMzkuNTE1NjI1IDAgTCAzNy4wMzEyNSAwIEwgNy43ODEyNSAtMjMuODQzNzUgTCA3Ljc4MTI1IDAgTCA0LjEwOTM3NSAwIEwgNC4xMDkzNzUgLTI5LjUxNTYyNSBMIDYuNjA5Mzc1IC0yOS41MTU2MjUgTCAzNS44NTkzNzUgLTUuNjg3NSBMIDM1Ljg1OTM3NSAtMjkuNTE1NjI1IEwgMzkuNTE1NjI1IC0yOS41MTU2MjUgWiBNIDM5LjUxNTYyNSAwICIvPgo8L3N5bWJvbD4KPHN5bWJvbCBvdmVyZmxvdz0idmlzaWJsZSIgaWQ9ImdseXBoMC02Ij4KPHBhdGggc3R5bGU9InN0cm9rZTpub25lOyIgZD0iTSAyOS45NTMxMjUgMCBMIDMuMDkzNzUgMCBMIDMuMDkzNzUgLTMuNjU2MjUgTCAyOS45NTMxMjUgLTMuNjU2MjUgQyAzMC43ODUxNTYgLTMuNjU2MjUgMzEuNSAtMy45NTMxMjUgMzIuMDkzNzUgLTQuNTQ2ODc1IEMgMzIuNjk1MzEyIC01LjE0ODQzOCAzMyAtNS44NjcxODggMzMgLTYuNzAzMTI1IEwgMzMgLTkuODc1IEMgMzMgLTEwLjY5NTMxMiAzMi43MTg3NSAtMTEuMzk4NDM4IDMyLjE1NjI1IC0xMS45ODQzNzUgQyAzMS41OTM3NSAtMTIuNTY2NDA2IDMwLjg5MDYyNSAtMTIuODc4OTA2IDMwLjA0Njg3NSAtMTIuOTIxODc1IEwgNy45Njg3NSAtMTIuOTIxODc1IEwgNy45Njg3NSAtMTYuNTkzNzUgTCAzMC4wNDY4NzUgLTE2LjU5Mzc1IEMgMzAuODkwNjI1IC0xNi42MzI4MTIgMzEuNTkzNzUgLTE2Ljk0NTMxMiAzMi4xNTYyNSAtMTcuNTMxMjUgQyAzMi43MTg3NSAtMTguMTEzMjgxIDMzIC0xOC44MTY0MDYgMzMgLTE5LjY0MDYyNSBMIDMzIC0yMi44MTI1IEMgMzMgLTIzLjY0NDUzMSAzMi42OTUzMTIgLTI0LjM1OTM3NSAzMi4wOTM3NSAtMjQuOTUzMTI1IEMgMzEuNSAtMjUuNTU0Njg4IDMwLjc4NTE1NiAtMjUuODU5Mzc1IDI5Ljk1MzEyNSAtMjUuODU5Mzc1IEwgMy4wOTM3NSAtMjUuODU5Mzc1IEwgMy4wOTM3NSAtMjkuNTE1NjI1IEwgMjkuOTUzMTI1IC0yOS41MTU2MjUgQyAzMS44MDQ2ODggLTI5LjUxNTYyNSAzMy4zODI4MTIgLTI4Ljg1OTM3NSAzNC42ODc1IC0yNy41NDY4NzUgQyAzNiAtMjYuMjQyMTg4IDM2LjY1NjI1IC0yNC42NjQwNjIgMzYuNjU2MjUgLTIyLjgxMjUgTCAzNi42NTYyNSAtMTkuNjQwNjI1IEMgMzYuNjU2MjUgLTE3LjcxMDkzOCAzNS45NTcwMzEgLTE2LjA4NTkzOCAzNC41NjI1IC0xNC43NjU2MjUgQyAzNS45NTcwMzEgLTEzLjQyOTY4OCAzNi42NTYyNSAtMTEuODAwNzgxIDM2LjY1NjI1IC05Ljg3NSBMIDM2LjY1NjI1IC02LjcwMzEyNSBDIDM2LjY1NjI1IC00Ljg1OTM3NSAzNiAtMy4yODEyNSAzNC42ODc1IC0xLjk2ODc1IEMgMzMuMzgyODEyIC0wLjY1NjI1IDMxLjgwNDY4OCAwIDI5Ljk1MzEyNSAwIFogTSAyOS45NTMxMjUgMCAiLz4KPC9zeW1ib2w+CjxzeW1ib2wgb3ZlcmZsb3c9InZpc2libGUiIGlkPSJnbHlwaDAtNyI+CjxwYXRoIHN0eWxlPSJzdHJva2U6bm9uZTsiIGQ9Ik0gMzcuNjg3NSAwIEwgNC4xMDkzNzUgMCBMIDQuMTA5Mzc1IC0yOS41MzEyNSBMIDM3LjY4NzUgLTI5LjUzMTI1IEwgMzcuNjg3NSAtMjUuODc1IEwgNy43ODEyNSAtMjUuODc1IEwgNy43ODEyNSAtMTYuNTkzNzUgTCAzNC4yMzQzNzUgLTE2LjU5Mzc1IEwgMzQuMjM0Mzc1IC0xMi45MjE4NzUgTCA3Ljc4MTI1IC0xMi45MjE4NzUgTCA3Ljc4MTI1IC0zLjY1NjI1IEwgMzcuNjg3NSAtMy42NTYyNSBaIE0gMzcuNjg3NSAwICIvPgo8L3N5bWJvbD4KPC9nPgo8Y2xpcFBhdGggaWQ9ImNsaXAxIj4KICA8cGF0aCBkPSJNIDkuNjY0MDYyIDkuNjY0MDYyIEwgMzY1IDkuNjY0MDYyIEwgMzY1IDM2NSBMIDkuNjY0MDYyIDM2NSBaIE0gOS42NjQwNjIgOS42NjQwNjIgIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPGcgaWQ9InN1cmZhY2UxIj4KPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjM3NSIgaGVpZ2h0PSIzNzQuOTk5OTkxIiBzdHlsZT0iZmlsbDpyZ2IoMTAwJSwxMDAlLDEwMCUpO2ZpbGwtb3BhY2l0eToxO3N0cm9rZTpub25lOyIvPgo8cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMzc1IiBoZWlnaHQ9IjM3NC45OTk5OTEiIHN0eWxlPSJmaWxsOnJnYigxMDAlLDEwMCUsMTAwJSk7ZmlsbC1vcGFjaXR5OjE7c3Ryb2tlOm5vbmU7Ii8+CjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIzNzUiIGhlaWdodD0iMzc0Ljk5OTk5MSIgc3R5bGU9ImZpbGw6cmdiKDEwMCUsMTAwJSwxMDAlKTtmaWxsLW9wYWNpdHk6MTtzdHJva2U6bm9uZTsiLz4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAxKSIgY2xpcC1ydWxlPSJub256ZXJvIj4KPHBhdGggc3R5bGU9IiBzdHJva2U6bm9uZTtmaWxsLXJ1bGU6bm9uemVybztmaWxsOnJnYigwJSwwJSwwJSk7ZmlsbC1vcGFjaXR5OjE7IiBkPSJNIDE4Ny4zMzIwMzEgMzY1IEMgODkuMTc1NzgxIDM2NSA5LjY2NDA2MiAyODQuOTQxNDA2IDkuNjY0MDYyIDE4Ny4zMzIwMzEgQyA5LjY2NDA2MiA4OS43MjY1NjIgODkuMTc1NzgxIDkuNjY0MDYyIDE4Ny4zMzIwMzEgOS42NjQwNjIgQyAyODUuNDg4MjgxIDkuNjY0MDYyIDM2NSA4OS4xNzU3ODEgMzY1IDE4Ny4zMzIwMzEgQyAzNjUgMjg1LjQ4ODI4MSAyODQuOTQxNDA2IDM2NSAxODcuMzMyMDMxIDM2NSBaIE0gMTg3LjMzMjAzMSAyMC42MzI4MTIgQyA5NS4yMTA5MzggMjAuNjMyODEyIDIwLjYzMjgxMiA5NS4yMTA5MzggMjAuNjMyODEyIDE4Ny4zMzIwMzEgQyAyMC42MzI4MTIgMjc5LjQ1NzAzMSA5NS4yMTA5MzggMzU0LjAzNTE1NiAxODcuMzMyMDMxIDM1NC4wMzUxNTYgQyAyNzkuNDU3MDMxIDM1NC4wMzUxNTYgMzU0LjAzNTE1NiAyNzkuNDU3MDMxIDM1NC4wMzUxNTYgMTg3LjMzMjAzMSBDIDM1NC4wMzUxNTYgOTUuMjEwOTM4IDI3OC45MTAxNTYgMjAuNjMyODEyIDE4Ny4zMzIwMzEgMjAuNjMyODEyIFogTSAxODcuMzMyMDMxIDIwLjYzMjgxMiAiLz4KPC9nPgo8ZyBzdHlsZT0iZmlsbDpyZ2IoMCUsMCUsMCUpO2ZpbGwtb3BhY2l0eToxOyI+CiAgPHVzZSB4bGluazpocmVmPSIjZ2x5cGgwLTEiIHg9IjMwLjY3Nzk5NSIgeT0iMjAwLjU0MDg4NSIvPgo8L2c+CjxnIHN0eWxlPSJmaWxsOnJnYigwJSwwJSwwJSk7ZmlsbC1vcGFjaXR5OjE7Ij4KICA8dXNlIHhsaW5rOmhyZWY9IiNnbHlwaDAtMiIgeD0iNzkuOTk0NTQyIiB5PSIyMDAuNTQwODg1Ii8+CjwvZz4KPGcgc3R5bGU9ImZpbGw6cmdiKDAlLDAlLDAlKTtmaWxsLW9wYWNpdHk6MTsiPgogIDx1c2UgeGxpbms6aHJlZj0iI2dseXBoMC0zIiB4PSIxMjMuMDc0NDgxIiB5PSIyMDAuNTQwODg1Ii8+CjwvZz4KPGcgc3R5bGU9ImZpbGw6cmdiKDAlLDAlLDAlKTtmaWxsLW9wYWNpdHk6MTsiPgogIDx1c2UgeGxpbms6aHJlZj0iI2dseXBoMC00IiB4PSIxNjUuNjgxMDE0IiB5PSIyMDAuNTQwODg1Ii8+CjwvZz4KPGcgc3R5bGU9ImZpbGw6cmdiKDAlLDAlLDAlKTtmaWxsLW9wYWNpdHk6MTsiPgogIDx1c2UgeGxpbms6aHJlZj0iI2dseXBoMC01IiB4PSIxNzcuNTc3OTExIiB5PSIyMDAuNTQwODg1Ii8+CjwvZz4KPGcgc3R5bGU9ImZpbGw6cmdiKDEwMCUsNTYuODU4ODI2JSwzMC4xOTg2NjklKTtmaWxsLW9wYWNpdHk6MTsiPgogIDx1c2UgeGxpbms6aHJlZj0iI2dseXBoMC02IiB4PSIyMjEuMjEwMjE2IiB5PSIyMDAuNTQwODg1Ii8+CjwvZz4KPGcgc3R5bGU9ImZpbGw6cmdiKDAlLDAlLDAlKTtmaWxsLW9wYWNpdHk6MTsiPgogIDx1c2UgeGxpbms6aHJlZj0iI2dseXBoMC03IiB4PSIyNjAuOTQ0MjI3IiB5PSIyMDAuNTQwODg1Ii8+CjwvZz4KPGcgc3R5bGU9ImZpbGw6cmdiKDAlLDAlLDAlKTtmaWxsLW9wYWNpdHk6MTsiPgogIDx1c2UgeGxpbms6aHJlZj0iI2dseXBoMC0zIiB4PSIzMDEuNzE4ODg1IiB5PSIyMDAuNTQwODg1Ii8+CjwvZz4KPC9nPgo8L3N2Zz4K
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: marin3r-controller-manager
+      deployments:
+        - name: marin3r-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - args:
+                      - --secure-listen-address=0.0.0.0:8443
+                      - --upstream=http://127.0.0.1:8080/
+                      - --logtostderr=true
+                      - --v=10
+                    image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+                    name: kube-rbac-proxy
+                    ports:
+                      - containerPort: 8443
+                        name: https
+                    resources: {}
+                  - args:
+                      - operator
+                      - --metrics-addr=127.0.0.1:8080
+                      - --enable-leader-election
+                    command:
+                      - /manager
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                    image: quay.io/3scale/marin3r:v0.7.0-alpha5
+                    name: manager
+                    resources:
+                      limits:
+                        cpu: 300m
+                        memory: 300Mi
+                      requests:
+                        cpu: 100m
+                        memory: 100Mi
+                serviceAccountName: marin3r-controller-manager
+                terminationGracePeriodSeconds: 10
+        - name: marin3r-controller-webhook
+          spec:
+            replicas: 2
+            selector:
+              matchLabels:
+                control-plane: controller-webhook
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  control-plane: controller-webhook
+              spec:
+                containers:
+                  - args:
+                      - webhook
+                      - --tls-dir=/apiserver.local.config/certificates
+                      - --tls-cert-name=apiserver.crt
+                      - --tls-key-name=apiserver.key
+                    command:
+                      - /manager
+                    image: quay.io/3scale/marin3r:v0.7.0-alpha5
+                    name: webhook
+                    ports:
+                      - containerPort: 9443
+                        name: webhook-server
+                        protocol: TCP
+                    resources: {}
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps/status
+              verbs:
+                - get
+                - update
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - services
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - envoybootstraps
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - envoybootstraps/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - envoyconfigrevisions
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - envoyconfigrevisions/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - envoyconfigs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - envoyconfigs/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - operator.marin3r.3scale.net
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - operator.marin3r.3scale.net
+              resources:
+                - discoveryservicecertificates
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.marin3r.3scale.net
+              resources:
+                - discoveryservicecertificates/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - rolebindings
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - watch
+          serviceAccountName: marin3r-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - envoy
+    - discovery
+    - controlplane
+    - proxy
+    - sidecar
+    - xds
+    - network
+  links:
+    - name: GitHub
+      url: https://github.com/3scale/marin3r
+  maintainers:
+    - email: 3scale-operations+marin3r@redhat.com
+      name: 3scale Operations Team
+  maturity: alpha
+  provider:
+    name: threescale
+  version: 0.7.0-alpha5
+  webhookdefinitions:
+    - admissionReviewVersions:
+        - v1beta1
+      containerPort: 9443
+      deploymentName: marin3r-controller-webhook
+      failurePolicy: Fail
+      generateName: sidecar-injector.marin3r.3scale.net
+      matchPolicy: Equivalent
+      objectSelector:
+        matchLabels:
+          marin3r.3scale.net/status: enabled
+      reinvocationPolicy: Never
+      rules:
+        - apiGroups:
+            - ""
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+          resources:
+            - pods
+          scope: Namespaced
+      sideEffects: None
+      timeoutSeconds: 5
+      type: MutatingAdmissionWebhook
+      webhookPath: /pod-v1-mutate

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/operator.marin3r.3scale.net_discoveryservicecertificates.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/operator.marin3r.3scale.net_discoveryservicecertificates.yaml
@@ -1,0 +1,139 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: discoveryservicecertificates.operator.marin3r.3scale.net
+spec:
+  group: operator.marin3r.3scale.net
+  names:
+    kind: DiscoveryServiceCertificate
+    listKind: DiscoveryServiceCertificateList
+    plural: discoveryservicecertificates
+    singular: discoveryservicecertificate
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: DiscoveryServiceCertificate is used to create certificates, either self-signed or by using a cert-manager CA issuer. This object is used by the DiscoveryService controller to create the required certificates for the different components of the discovery service. Direct use of DiscoveryServiceCertificate objects is discouraged.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DiscoveryServiceCertificateSpec defines the desired state of DiscoveryServiceCertificate
+          properties:
+            certificateRenewalNotification:
+              description: CertificateRenewalConfig configures the certificate renewal process. If unset default behavior is to renew the certificate but not notify of renewals.
+              properties:
+                enabled:
+                  description: Enabled is a flag to enable or disable renewal of the certificate
+                  type: boolean
+              required:
+              - enabled
+              type: object
+            commonName:
+              description: CommonName is the CommonName of the certificate
+              type: string
+            hosts:
+              description: Hosts is the list of hosts the certificate is valid for. Only use when 'IsServerCertificate' is true. If unset, the CommonName field will be used to populate the valid hosts of the certificate.
+              items:
+                type: string
+              type: array
+            isCA:
+              description: IsCA is a boolean specifying that the certificate is a CA
+              type: boolean
+            secretRef:
+              description: SecretRef is a reference to the secret that will hold the certificate and the private key.
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret name must be unique.
+                  type: string
+              type: object
+            server:
+              description: IsServerCertificate is a boolean specifying if the certificate should be issued with server auth usage enabled
+              type: boolean
+            signer:
+              description: Signer specifies  the signer to use to create this certificate. Supported signers are CertManager and SelfSigned.
+              properties:
+                caSigned:
+                  description: CASigned holds specific configuration for the CASigned signer
+                  properties:
+                    caSecretRef:
+                      description: A reference to a Secret containing the CA
+                      properties:
+                        name:
+                          description: Name is unique within a namespace to reference a secret resource.
+                          type: string
+                        namespace:
+                          description: Namespace defines the space within which the secret name must be unique.
+                          type: string
+                      type: object
+                  required:
+                  - caSecretRef
+                  type: object
+                selfSigned:
+                  description: SelfSigned holds specific configuration for the SelfSigned signer
+                  type: object
+              type: object
+            validFor:
+              description: ValidFor specifies the validity of the certificate in seconds
+              format: int64
+              type: integer
+          required:
+          - commonName
+          - secretRef
+          - signer
+          - validFor
+          type: object
+        status:
+          description: DiscoveryServiceCertificateStatus defines the observed state of DiscoveryServiceCertificate
+          properties:
+            conditions:
+              description: Conditions represent the latest available observations of an object's state
+              items:
+                description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/operator.marin3r.3scale.net_discoveryservices.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha5/manifests/operator.marin3r.3scale.net_discoveryservices.yaml
@@ -1,0 +1,148 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: discoveryservices.operator.marin3r.3scale.net
+spec:
+  group: operator.marin3r.3scale.net
+  names:
+    kind: DiscoveryService
+    listKind: DiscoveryServiceList
+    plural: discoveryservices
+    singular: discoveryservice
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: DiscoveryService represents an envoy discovery service server. Currently only one DiscoveryService per cluster is supported.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DiscoveryServiceSpec defines the desired state of DiscoveryService
+          properties:
+            ServiceConfig:
+              description: ServiceConfig configures the way the DiscoveryService endpoints are exposed
+              properties:
+                name:
+                  type: string
+                type:
+                  description: ServiceType is an enum with the available discovery service Service types
+                  type: string
+              type: object
+            debug:
+              description: Debug enables debugging log level for the discovery service controllers. It is safe to use since secret data is never shown in the logs.
+              type: boolean
+            image:
+              description: Image holds the image to use for the discovery service Deployment
+              type: string
+            metricsPort:
+              description: MetricsPort is the port where metrics are served. Defaults to 8383.
+              format: int32
+              type: integer
+            pkiConfg:
+              description: PKIConfig has configuration for the PKI that marin3r manages for the different certificates it requires
+              properties:
+                rootCertificateAuthority:
+                  description: CertificateOptions specifies options to generate the server certificate used both for the xDS server and the mutating webhook server.
+                  properties:
+                    duration:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - duration
+                  - secretName
+                  type: object
+                serverCertificate:
+                  description: CertificateOptions specifies options to generate the server certificate used both for the xDS server and the mutating webhook server.
+                  properties:
+                    duration:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - duration
+                  - secretName
+                  type: object
+              required:
+              - rootCertificateAuthority
+              - serverCertificate
+              type: object
+            resources:
+              description: Resources holds the Resource Requirements to use for the discovery service Deployment. When not set it defaults to no resource requests nor limits. CPU and Memory resources are supported.
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            xdsPort:
+              description: XdsServerPort is the port where the xDS server listens. Defaults to 18000.
+              format: int32
+              type: integer
+          type: object
+        status:
+          description: DiscoveryServiceStatus defines the observed state of DiscoveryService
+          properties:
+            conditions:
+              description: Conditions represent the latest available observations of an object's state
+              items:
+                description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha5/metadata/annotations.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha5/metadata/annotations.yaml
@@ -1,0 +1,11 @@
+annotations:
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: marin3r-threescale
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.1.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha5/tests/scorecard/config.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha5/tests/scorecard/config.yaml
@@ -1,0 +1,49 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.1.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.1.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.1.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.1.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.1.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.1.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha6/bundle.Dockerfile
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha6/bundle.Dockerfile
@@ -1,0 +1,15 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=marin3r-threescale
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.1.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+COPY manifests /manifests/
+COPY metadata /metadata/
+COPY tests/scorecard /tests/scorecard/

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r-controller-manager_v1_serviceaccount.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r-controller-manager_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: marin3r-controller-manager

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r-metrics-reader_rbac.authorization.k8s.io_v1beta1_clusterrole.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r-metrics-reader_rbac.authorization.k8s.io_v1beta1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: marin3r-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r.3scale.net_envoybootstraps.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r.3scale.net_envoybootstraps.yaml
@@ -1,0 +1,105 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: envoybootstraps.marin3r.3scale.net
+spec:
+  group: marin3r.3scale.net
+  names:
+    kind: EnvoyBootstrap
+    listKind: EnvoyBootstrapList
+    plural: envoybootstraps
+    singular: envoybootstrap
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: EnvoyBootstrap is the Schema for the envoybootstraps API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: EnvoyBootstrapSpec defines the desired state of EnvoyBootstrap
+          properties:
+            clientCertificate:
+              description: ClientCertificate is a struct containing options for the certificate used to authenticate with the discovery service
+              properties:
+                directory:
+                  description: Directory defines the directory in the envoy container where the certificate will be mounted
+                  type: string
+                duration:
+                  description: The requested ‘duration’ (i.e. lifetime) of the Certificate
+                  type: string
+                secretName:
+                  description: The Secret where the certificate will be stored
+                  type: string
+              required:
+              - directory
+              - duration
+              - secretName
+              type: object
+            discoveryService:
+              description: DiscoveryService is the name of the DiscoveryService resource the envoy will be a client of
+              type: string
+            envoyStaticConfig:
+              description: EnvoyStaticConfig is a struct that controls options for the envoy's static config file
+              properties:
+                adminAccessLogPath:
+                  description: AdminAccessLogPath configures where the envoy's admin server logs are written to
+                  type: string
+                adminBindAddress:
+                  description: AdminBindAddress is where envoy's admin server binds to.
+                  type: string
+                configFile:
+                  description: ConfigFile is the path of envoy's bootstrap config file
+                  type: string
+                configMapNameV2:
+                  description: The ConfigMap where the envoy client v2 static config will be stored
+                  type: string
+                configMapNameV3:
+                  description: The ConfigMap where the envoy client v3 static config will be stored
+                  type: string
+                resourcesDir:
+                  description: ResourcesDir is the path where resource files are loaded from. It is used to load discovery messages directly from the filesystem, for example in order to be able to bootstrap certificates and support rotation when they are modified.
+                  type: string
+                rtdsLayerResourceName:
+                  description: RtdsLayerResourceName is the resource name that the envoy client will request when askikng the discovery service for Runtime resources.
+                  type: string
+              required:
+              - adminAccessLogPath
+              - adminBindAddress
+              - configFile
+              - configMapNameV2
+              - configMapNameV3
+              - resourcesDir
+              - rtdsLayerResourceName
+              type: object
+          required:
+          - clientCertificate
+          - discoveryService
+          - envoyStaticConfig
+          type: object
+        status:
+          description: EnvoyBootstrapStatus defines the observed state of EnvoyBootstrap
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r.3scale.net_envoyconfigrevisions.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r.3scale.net_envoyconfigrevisions.yaml
@@ -1,0 +1,240 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: envoyconfigrevisions.marin3r.3scale.net
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.nodeID
+    name: Node ID
+    type: string
+  - JSONPath: .spec.envoyAPI
+    name: Envoy API
+    type: string
+  - JSONPath: .spec.version
+    name: Version
+    type: string
+  - JSONPath: .status.published
+    name: Published
+    type: boolean
+  - JSONPath: .metadata.creationTimestamp
+    format: date-time
+    name: Created At
+    type: string
+  - JSONPath: .status.lastPublishedAt
+    format: date-time
+    name: Last Published At
+    type: string
+  - JSONPath: .status.tainted
+    name: Tainted
+    type: boolean
+  group: marin3r.3scale.net
+  names:
+    kind: EnvoyConfigRevision
+    listKind: EnvoyConfigRevisionList
+    plural: envoyconfigrevisions
+    shortNames:
+    - ecr
+    singular: envoyconfigrevision
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: EnvoyConfigRevision holds an specific version of the EnvoyConfig resources. EnvoyConfigRevisions are automatically created and deleted  by the EnvoyConfig controller and are not intended to be directly used. Use EnvoyConfig objects instead.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: EnvoyConfigRevisionSpec defines the desired state of EnvoyConfigRevision
+          properties:
+            envoyAPI:
+              description: EnvoyAPI is the version of envoy's API to use. Defaults to v2.
+              enum:
+              - v2
+              - v3
+              type: string
+            envoyResources:
+              description: EnvoyResources holds the different types of resources suported by the envoy discovery service
+              properties:
+                clusters:
+                  description: 'Clusters is a list of the envoy Cluster resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cluster.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                endpoints:
+                  description: 'Endpoints is a list of the envoy ClusterLoadAssignment resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/endpoint.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                listeners:
+                  description: 'Listeners is a list of the envoy Listener resource type. V2 referece: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                routes:
+                  description: 'Routes is a list of the envoy Route resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                runtime:
+                  description: 'Runtimes is a list of the envoy Runtime resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/discovery/v2/rtds.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/runtime/v3/rtds.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                secrets:
+                  description: Secrets is a list of references to Kubernetes Secret objects.
+                  items:
+                    description: EnvoySecretResource holds a reference to a k8s Secret from where to take a secret from
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      ref:
+                        description: Ref is a reference to a Kubernetes Secret of type "kubernetes.io/tls" from which an envoy Secret resource will be automatically created.
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which the secret name must be unique.
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    - ref
+                    type: object
+                  type: array
+              type: object
+            nodeID:
+              description: NodeID holds the envoy identifier for the discovery service to know which set of resources to send to each of the envoy clients that connect to it.
+              type: string
+            serialization:
+              description: Serialization specicifies the serialization format used to describe the resources. "json" and "yaml" are supported. "json" is used if unset.
+              enum:
+              - json
+              - b64json
+              - yaml
+              type: string
+            version:
+              description: Version is a hash of the EnvoyResources field
+              type: string
+          required:
+          - envoyResources
+          - nodeID
+          - version
+          type: object
+        status:
+          description: EnvoyConfigRevisionStatus defines the observed state of EnvoyConfigRevision
+          properties:
+            conditions:
+              description: Conditions represent the latest available observations of an object's state
+              items:
+                description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            lastPublishedAt:
+              description: LastPublishedAt indicates the last time this config review transitioned to published
+              format: date-time
+              type: string
+            published:
+              description: Published signals if the EnvoyConfigRevision is the one currently published in the xds server cache
+              type: boolean
+            tainted:
+              description: Tainted indicates whether the EnvoyConfigRevision is eligible for publishing or not
+              type: boolean
+          required:
+          - conditions
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r.3scale.net_envoyconfigs.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r.3scale.net_envoyconfigs.yaml
@@ -1,0 +1,263 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: envoyconfigs.marin3r.3scale.net
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.nodeID
+    name: Node ID
+    type: string
+  - JSONPath: .spec.envoyAPI
+    name: Envoy API
+    type: string
+  - JSONPath: .status.desiredVersion
+    name: Desired Version
+    type: string
+  - JSONPath: .status.publishedVersion
+    name: Published Version
+    type: string
+  - JSONPath: .status.cacheState
+    name: Cache State
+    type: string
+  group: marin3r.3scale.net
+  names:
+    kind: EnvoyConfig
+    listKind: EnvoyConfigList
+    plural: envoyconfigs
+    shortNames:
+    - ec
+    singular: envoyconfig
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: EnvoyConfig holds the configuration for a given envoy nodeID. The spec of an EnvoyConfig object holds the envoy resources that conform the desired configuration for the given nodeID and that the discovery service will send to any envoy client that identifies itself with that nodeID.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: EnvoyConfigSpec defines the desired state of EnvoyConfig
+          properties:
+            envoyAPI:
+              description: EnvoyAPI is the version of envoy's API to use. Defaults to v2.
+              enum:
+              - v2
+              - v3
+              type: string
+            envoyResources:
+              description: EnvoyResources holds the different types of resources suported by the envoy discovery service
+              properties:
+                clusters:
+                  description: 'Clusters is a list of the envoy Cluster resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cluster.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                endpoints:
+                  description: 'Endpoints is a list of the envoy ClusterLoadAssignment resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/endpoint.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                listeners:
+                  description: 'Listeners is a list of the envoy Listener resource type. V2 referece: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                routes:
+                  description: 'Routes is a list of the envoy Route resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                runtime:
+                  description: 'Runtimes is a list of the envoy Runtime resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/discovery/v2/rtds.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/runtime/v3/rtds.proto'
+                  items:
+                    description: EnvoyResource holds serialized representation of an envoy resource
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      value:
+                        description: Value is the serialized representation of the envoy resource
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                secrets:
+                  description: Secrets is a list of references to Kubernetes Secret objects.
+                  items:
+                    description: EnvoySecretResource holds a reference to a k8s Secret from where to take a secret from
+                    properties:
+                      name:
+                        description: Name of the envoy resource
+                        type: string
+                      ref:
+                        description: Ref is a reference to a Kubernetes Secret of type "kubernetes.io/tls" from which an envoy Secret resource will be automatically created.
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which the secret name must be unique.
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    - ref
+                    type: object
+                  type: array
+              type: object
+            nodeID:
+              description: NodeID holds the envoy identifier for the discovery service to know which set of resources to send to each of the envoy clients that connect to it.
+              type: string
+            serialization:
+              description: Serialization specicifies the serialization format used to describe the resources. "json" and "yaml" are supported. "json" is used if unset.
+              enum:
+              - json
+              - b64json
+              - yaml
+              type: string
+          required:
+          - envoyResources
+          - nodeID
+          type: object
+        status:
+          description: EnvoyConfigStatus defines the observed state of EnvoyConfig
+          properties:
+            cacheState:
+              description: CacheState summarizes all the observations about the EnvoyConfig to give the user a concrete idea on the general status of the discovery servie cache. It is intended only for human consumption. Other controllers should relly on conditions to determine the status of the discovery server cache.
+              type: string
+            conditions:
+              description: Conditions represent the latest available observations of an object's state
+              items:
+                description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            desiredVersion:
+              description: DesiredVersion represents the resources version described in the spec of the EnvoyConfig object
+              type: string
+            publishedVersion:
+              description: PublishedVersion is the config version currently served by the envoy discovery service for the give nodeID
+              type: string
+            revisions:
+              description: ConfigRevisions is an ordered list of references to EnvoyConfigRevision objects
+              items:
+                description: ConfigRevisionRef holds a reference to EnvoyConfigRevision object
+                properties:
+                  ref:
+                    description: Ref is a reference to the EnvoyConfigRevision object that holds the configuration matching the Version field.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  version:
+                    description: Version is a hash of the EnvoyResources field
+                    type: string
+                required:
+                - ref
+                - version
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r.clusterserviceversion.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r.clusterserviceversion.yaml
@@ -769,7 +769,7 @@ spec:
   maturity: alpha
   provider:
     name: threescale
-  replaces: marin3r-threescale.v0.7.0-alpha5
+  replaces: marin3r-threescale.0.7.0-alpha5
   version: 0.7.0-alpha6
   webhookdefinitions:
     - admissionReviewVersions:

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r.clusterserviceversion.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/marin3r.clusterserviceversion.yaml
@@ -1,0 +1,799 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "marin3r.3scale.net/v1alpha1",
+          "kind": "EnvoyBootstrap",
+          "metadata": {
+            "name": "envoybootstrap-sample"
+          },
+          "spec": {
+            "clientCertificate": {
+              "directory": "/etc/envoy/tls/client",
+              "duration": "1h",
+              "secretName": "discoveryservice-client-certificate"
+            },
+            "discoveryService": "instance",
+            "envoyStaticConfig": {
+              "adminAccessLogPath": "/dev/null",
+              "adminBindAddress": "0.0.0.0:9901",
+              "configFile": "config.yaml",
+              "configMapNameV2": "envoy-bootstrap-v2",
+              "configMapNameV3": "envoy-bootstrap-v3",
+              "resourcesDir": "/etc/envoy/bootstrap",
+              "rtdsLayerResourceName": "runtime"
+            }
+          }
+        },
+        {
+          "apiVersion": "marin3r.3scale.net/v1alpha1",
+          "kind": "EnvoyConfig",
+          "metadata": {
+            "name": "example",
+            "namespace": "my-namespace"
+          },
+          "spec": {
+            "envoyResources": {
+              "clusters": [
+                {
+                  "name": "example",
+                  "value": "name: example\nconnect_timeout: 2s\ntype: STRICT_DNS\nlb_policy: ROUND_ROBIN\nload_assignment:\n  cluster_name: example\n  endpoints: []\n"
+                }
+              ],
+              "listeners": [
+                {
+                  "name": "http",
+                  "value": "name: http\naddress:\n  socket_address:\n    address: 0.0.0.0\n    port_value: 8080\nfilter_chains:\n- filters:\n  - name: envoy.http_connection_manager\n    typed_config:\n      \"@type\": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager\n      stat_prefix: ingress_http\n      route_config:\n        name: local_route\n        virtual_hosts:\n        - name: example\n          domains: [\"*\"]\n          routes:\n          - match:\n              prefix: \"/\"\n            route:\n              cluster: example\n      http_filters:\n      - name: envoy.router\n"
+                }
+              ],
+              "secrets": [
+                {
+                  "name": "example.com",
+                  "ref": {
+                    "name": "example-cert",
+                    "namespace": "my-namespace"
+                  }
+                }
+              ]
+            },
+            "nodeID": "example",
+            "serialization": "yaml"
+          }
+        },
+        {
+          "apiVersion": "marin3r.3scale.net/v1alpha1",
+          "kind": "EnvoyConfigRevision",
+          "metadata": {
+            "name": "example",
+            "namespace": "my-namespace"
+          },
+          "spec": {
+            "envoyResources": {
+              "clusters": [
+                {
+                  "name": "example",
+                  "value": "name: example\nconnect_timeout: 2s\ntype: STRICT_DNS\nlb_policy: ROUND_ROBIN\nload_assignment:\n  cluster_name: example\n  endpoints: []\n"
+                }
+              ],
+              "listeners": [
+                {
+                  "name": "http",
+                  "value": "name: http\naddress:\n  socket_address:\n    address: 0.0.0.0\n    port_value: 8080\nfilter_chains:\n- filters:\n  - name: envoy.http_connection_manager\n    typed_config:\n      \"@type\": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager\n      stat_prefix: ingress_http\n      route_config:\n        name: local_route\n        virtual_hosts:\n        - name: example\n          domains: [\"*\"]\n          routes:\n          - match:\n              prefix: \"/\"\n            route:\n              cluster: example\n      http_filters:\n      - name: envoy.router\n"
+                }
+              ],
+              "secrets": [
+                {
+                  "name": "example.com",
+                  "ref": {
+                    "name": "example-cert",
+                    "namespace": "my-namespace"
+                  }
+                }
+              ]
+            },
+            "nodeID": "example",
+            "serialization": "yaml",
+            "version": "hash"
+          }
+        },
+        {
+          "apiVersion": "operator.marin3r.3scale.net/v1alpha1",
+          "kind": "DiscoveryService",
+          "metadata": {
+            "name": "instance"
+          },
+          "spec": {
+            "debug": true,
+            "discoveryServiceNamespace": "default",
+            "enabledNamespaces": [
+              "test1",
+              "test2"
+            ],
+            "image": "quay.io/3scale/marin3r:latest"
+          }
+        },
+        {
+          "apiVersion": "operator.marin3r.3scale.net/v1alpha1",
+          "kind": "DiscoveryServiceCertificate",
+          "metadata": {
+            "name": "test-cert",
+            "namespace": "default"
+          },
+          "spec": {
+            "commonName": "test-client",
+            "secretRef": {
+              "name": "test-cert",
+              "namespace": "default"
+            },
+            "signer": {
+              "certManager": {
+                "clusterIssuer": "marin3r-instance"
+              }
+            },
+            "validFor": 3600
+          }
+        }
+      ]
+    capabilities: Basic Install
+    certified: "false"
+    containerImage: quay.io/3scale/marin3r
+    description: Manage an Envoy Discovery Service and a fleet of Envoy proxies.
+    operators.operatorframework.io/builder: operator-sdk-v1.1.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+    repository: https://github.com/3scale/marin3r
+    support: Red Hat, Inc.
+  name: marin3r-threescale.v0.7.0-alpha6
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: DiscoveryServiceCertificate is used to create certificates, either self-signed or by using a cert-manager CA issuer. This object is used by the DiscoveryService controller to create the required certificates for the different components of the discovery service. Direct use of DiscoveryServiceCertificate objects is discouraged.
+        displayName: DiscoveryServiceCertificate
+        kind: DiscoveryServiceCertificate
+        name: discoveryservicecertificates.operator.marin3r.3scale.net
+        specDescriptors:
+          - description: CertificateRenewalConfig configures the certificate renewal process. If unset default behavior is to renew the certificate but not notify of renewals.
+            displayName: Certificate Renewal Config
+            path: certificateRenewalNotification
+          - description: Enabled is a flag to enable or disable renewal of the certificate
+            displayName: Enabled
+            path: certificateRenewalNotification.enabled
+          - description: CommonName is the CommonName of the certificate
+            displayName: Common Name
+            path: commonName
+          - description: Hosts is the list of hosts the certificate is valid for. Only use when 'IsServerCertificate' is true. If unset, the CommonName field will be used to populate the valid hosts of the certificate.
+            displayName: Hosts
+            path: hosts
+          - description: IsCA is a boolean specifying that the certificate is a CA
+            displayName: Is CA
+            path: isCA
+          - description: SecretRef is a reference to the secret that will hold the certificate and the private key.
+            displayName: Secret Ref
+            path: secretRef
+          - description: IsServerCertificate is a boolean specifying if the certificate should be issued with server auth usage enabled
+            displayName: Is Server Certificate
+            path: server
+          - description: Signer specifies  the signer to use to create this certificate. Supported signers are CertManager and SelfSigned.
+            displayName: Signer
+            path: signer
+          - description: CASigned holds specific configuration for the CASigned signer
+            displayName: CASigned
+            path: signer.caSigned
+          - description: A reference to a Secret containing the CA
+            displayName: Secret Ref
+            path: signer.caSigned.caSecretRef
+          - description: SelfSigned holds specific configuration for the SelfSigned signer
+            displayName: Self Signed
+            path: signer.selfSigned
+          - description: ValidFor specifies the validity of the certificate in seconds
+            displayName: Valid For
+            path: validFor
+        statusDescriptors:
+          - description: Conditions represent the latest available observations of an object's state
+            displayName: Conditions
+            path: conditions
+        version: v1alpha1
+      - description: DiscoveryService represents an envoy discovery service server. Currently only one DiscoveryService per cluster is supported.
+        displayName: DiscoveryService
+        kind: DiscoveryService
+        name: discoveryservices.operator.marin3r.3scale.net
+        specDescriptors:
+          - description: ServiceConfig configures the way the DiscoveryService endpoints are exposed
+            displayName: Service Config
+            path: ServiceConfig
+          - displayName: Name
+            path: ServiceConfig.name
+          - displayName: Type
+            path: ServiceConfig.type
+          - description: Debug enables debugging log level for the discovery service controllers. It is safe to use since secret data is never shown in the logs.
+            displayName: Debug
+            path: debug
+          - description: Image holds the image to use for the discovery service Deployment
+            displayName: Image
+            path: image
+          - description: MetricsPort is the port where metrics are served. Defaults to 8383.
+            displayName: Metrics Port
+            path: metricsPort
+          - description: PKIConfig has configuration for the PKI that marin3r manages for the different certificates it requires
+            displayName: PKIConfig
+            path: pkiConfg
+          - displayName: Root Certificate Authority
+            path: pkiConfg.rootCertificateAuthority
+          - displayName: Duration
+            path: pkiConfg.rootCertificateAuthority.duration
+          - displayName: Secret Name
+            path: pkiConfg.rootCertificateAuthority.secretName
+          - displayName: Server Certificate
+            path: pkiConfg.serverCertificate
+          - displayName: Duration
+            path: pkiConfg.serverCertificate.duration
+          - displayName: Secret Name
+            path: pkiConfg.serverCertificate.secretName
+          - description: Resources holds the Resource Requirements to use for the discovery service Deployment. When not set it defaults to no resource requests nor limits. CPU and Memory resources are supported.
+            displayName: Resources
+            path: resources
+          - description: XdsServerPort is the port where the xDS server listens. Defaults to 18000.
+            displayName: Xds Server Port
+            path: xdsPort
+        statusDescriptors:
+          - description: Conditions represent the latest available observations of an object's state
+            displayName: Conditions
+            path: conditions
+        version: v1alpha1
+      - description: EnvoyBootstrap is the Schema for the envoybootstraps API
+        displayName: EnvoyBootstrap
+        kind: EnvoyBootstrap
+        name: envoybootstraps.marin3r.3scale.net
+        specDescriptors:
+          - description: ClientCertificate is a struct containing options for the certificate used to authenticate with the discovery service
+            displayName: Client Certificate
+            path: clientCertificate
+          - description: Directory defines the directory in the envoy container where the certificate will be mounted
+            displayName: Directory
+            path: clientCertificate.directory
+          - description: The requested ‘duration’ (i.e. lifetime) of the Certificate
+            displayName: Duration
+            path: clientCertificate.duration
+          - description: The Secret where the certificate will be stored
+            displayName: Secret Name
+            path: clientCertificate.secretName
+          - description: DiscoveryService is the name of the DiscoveryService resource the envoy will be a client of
+            displayName: Discovery Service
+            path: discoveryService
+          - description: EnvoyStaticConfig is a struct that controls options for the envoy's static config file
+            displayName: Envoy Static Config
+            path: envoyStaticConfig
+          - description: AdminAccessLogPath configures where the envoy's admin server logs are written to
+            displayName: Admin Access Log Path
+            path: envoyStaticConfig.adminAccessLogPath
+          - description: AdminBindAddress is where envoy's admin server binds to.
+            displayName: Admin Bind Address
+            path: envoyStaticConfig.adminBindAddress
+          - description: ConfigFile is the path of envoy's bootstrap config file
+            displayName: Config File
+            path: envoyStaticConfig.configFile
+          - description: The ConfigMap where the envoy client v2 static config will be stored
+            displayName: Config Map Name V2
+            path: envoyStaticConfig.configMapNameV2
+          - description: The ConfigMap where the envoy client v3 static config will be stored
+            displayName: Config Map Name V3
+            path: envoyStaticConfig.configMapNameV3
+          - description: ResourcesDir is the path where resource files are loaded from. It is used to load discovery messages directly from the filesystem, for example in order to be able to bootstrap certificates and support rotation when they are modified.
+            displayName: Resources Dir
+            path: envoyStaticConfig.resourcesDir
+          - description: RtdsLayerResourceName is the resource name that the envoy client will request when askikng the discovery service for Runtime resources.
+            displayName: Rtds Layer Resource Name
+            path: envoyStaticConfig.rtdsLayerResourceName
+        version: v1alpha1
+      - description: EnvoyConfigRevision holds an specific version of the EnvoyConfig resources. EnvoyConfigRevisions are automatically created and deleted  by the EnvoyConfig controller and are not intended to be directly used. Use EnvoyConfig objects instead.
+        displayName: EnvoyConfigRevision
+        kind: EnvoyConfigRevision
+        name: envoyconfigrevisions.marin3r.3scale.net
+        specDescriptors:
+          - description: EnvoyAPI is the version of envoy's API to use. Defaults to v2.
+            displayName: Envoy API
+            path: envoyAPI
+          - description: EnvoyResources holds the different types of resources suported by the envoy discovery service
+            displayName: Envoy Resources
+            path: envoyResources
+          - description: NodeID holds the envoy identifier for the discovery service to know which set of resources to send to each of the envoy clients that connect to it.
+            displayName: Node ID
+            path: nodeID
+          - description: Serialization specicifies the serialization format used to describe the resources. "json" and "yaml" are supported. "json" is used if unset.
+            displayName: Serialization
+            path: serialization
+          - description: Version is a hash of the EnvoyResources field
+            displayName: Version
+            path: version
+        statusDescriptors:
+          - description: Conditions represent the latest available observations of an object's state
+            displayName: Conditions
+            path: conditions
+          - description: LastPublishedAt indicates the last time this config review transitioned to published
+            displayName: Last Published At
+            path: lastPublishedAt
+          - description: Published signals if the EnvoyConfigRevision is the one currently published in the xds server cache
+            displayName: Published
+            path: published
+          - description: Tainted indicates whether the EnvoyConfigRevision is eligible for publishing or not
+            displayName: Tainted
+            path: tainted
+        version: v1alpha1
+      - description: EnvoyConfig holds the configuration for a given envoy nodeID. The spec of an EnvoyConfig object holds the envoy resources that conform the desired configuration for the given nodeID and that the discovery service will send to any envoy client that identifies itself with that nodeID.
+        displayName: EnvoyConfig
+        kind: EnvoyConfig
+        name: envoyconfigs.marin3r.3scale.net
+        resources:
+          - kind: EnvoyConfigRevision
+            name: ""
+            version: v1alpha1
+        specDescriptors:
+          - description: EnvoyAPI is the version of envoy's API to use. Defaults to v2.
+            displayName: Envoy API
+            path: envoyAPI
+          - description: EnvoyResources holds the different types of resources suported by the envoy discovery service
+            displayName: Envoy Resources
+            path: envoyResources
+          - description: 'Clusters is a list of the envoy Cluster resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cluster.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto'
+            displayName: Clusters
+            path: envoyResources.clusters
+          - description: Name of the envoy resource
+            displayName: Name
+            path: envoyResources.clusters[0].name
+          - description: Value is the serialized representation of the envoy resource
+            displayName: Value
+            path: envoyResources.clusters[0].value
+          - description: 'Endpoints is a list of the envoy ClusterLoadAssignment resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/endpoint.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint.proto'
+            displayName: Endpoints
+            path: envoyResources.endpoints
+          - description: Name of the envoy resource
+            displayName: Name
+            path: envoyResources.endpoints[0].name
+          - description: Value is the serialized representation of the envoy resource
+            displayName: Value
+            path: envoyResources.endpoints[0].value
+          - description: 'Listeners is a list of the envoy Listener resource type. V2 referece: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto'
+            displayName: Listeners
+            path: envoyResources.listeners
+          - description: Name of the envoy resource
+            displayName: Name
+            path: envoyResources.listeners[0].name
+          - description: Value is the serialized representation of the envoy resource
+            displayName: Value
+            path: envoyResources.listeners[0].value
+          - description: 'Routes is a list of the envoy Route resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto'
+            displayName: Routes
+            path: envoyResources.routes
+          - description: Name of the envoy resource
+            displayName: Name
+            path: envoyResources.routes[0].name
+          - description: Value is the serialized representation of the envoy resource
+            displayName: Value
+            path: envoyResources.routes[0].value
+          - description: 'Runtimes is a list of the envoy Runtime resource type. V2 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/discovery/v2/rtds.proto V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/runtime/v3/rtds.proto'
+            displayName: Runtimes
+            path: envoyResources.runtime
+          - description: Name of the envoy resource
+            displayName: Name
+            path: envoyResources.runtime[0].name
+          - description: Value is the serialized representation of the envoy resource
+            displayName: Value
+            path: envoyResources.runtime[0].value
+          - description: Secrets is a list of references to Kubernetes Secret objects.
+            displayName: Secrets
+            path: envoyResources.secrets
+          - description: Name of the envoy resource
+            displayName: Name
+            path: envoyResources.secrets[0].name
+          - description: Ref is a reference to a Kubernetes Secret of type "kubernetes.io/tls" from which an envoy Secret resource will be automatically created.
+            displayName: Ref
+            path: envoyResources.secrets[0].ref
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:SecretReference
+          - description: NodeID holds the envoy identifier for the discovery service to know which set of resources to send to each of the envoy clients that connect to it.
+            displayName: Node ID
+            path: nodeID
+          - description: Serialization specicifies the serialization format used to describe the resources. "json" and "yaml" are supported. "json" is used if unset.
+            displayName: Serialization
+            path: serialization
+        statusDescriptors:
+          - description: CacheState summarizes all the observations about the EnvoyConfig to give the user a concrete idea on the general status of the discovery servie cache. It is intended only for human consumption. Other controllers should relly on conditions to determine the status of the discovery server cache.
+            displayName: Cache State
+            path: cacheState
+          - description: Conditions represent the latest available observations of an object's state
+            displayName: Conditions
+            path: conditions
+          - description: DesiredVersion represents the resources version described in the spec of the EnvoyConfig object
+            displayName: Desired Version
+            path: desiredVersion
+          - description: PublishedVersion is the config version currently served by the envoy discovery service for the give nodeID
+            displayName: Published Version
+            path: publishedVersion
+          - description: ConfigRevisions is an ordered list of references to EnvoyConfigRevision objects
+            displayName: Config Revisions
+            path: revisions
+          - description: Ref is a reference to the EnvoyConfigRevision object that holds the configuration matching the Version field.
+            displayName: Ref
+            path: revisions[0].ref
+          - description: Version is a hash of the EnvoyResources field
+            displayName: Version
+            path: revisions[0].version
+        version: v1alpha1
+  description: |
+    MARIN3R is an operator to manage an Envoy discovery service and a fleet of Envoy proxies that
+    connect to it to fetch their configurations dynamically. It's main purpose is to provide
+    an easy way to deploy a discovery service with the basic functionality already in place so you
+    can focus on developing your Envoy configurationss or even your own domain specifig CRDs leveraging
+    the ones that MARIN3R provides.
+
+
+    ## Managed installation (kind DiscoveryService)
+
+    * Basic installation and setup of an Envoy discovery service
+    * Automatic deployment of a kubernetes mutating admission webhook to inject Envoy sidecars in your pods
+    * Automatic configuration of Envoy sidecars to find the discovery service within the cluster
+    * Mututal TLS authentication between Envoy sidecars and the discovery service
+    * The discovery service and the Envoy proxies that conenct to it must live in the same namespace
+
+    ## Deploy Envoy configurations as kubernetes custom resources (kind EnvoyConfig)
+
+    * Each EnvoyConfig object holds Envoy resources that will be "pushed" to the appropriate set of pods
+    * Control which config goes to which pod directly using annotations on the pod
+    * The whole Envoy v2 API is supported
+    * Envoy resources can be both expressed as json or yaml
+    * A history of the last 10 configurations is kept per EnvoyConfig object
+    * Self-healing is attempted when the Envoy sidecars are not able to load the resources defined in the
+      EnvoyConfig by rolling back to a previous working config version
+
+    ## License
+    MARIN3R is licensed under the [Apache 2.0 license](https://github.com/3scale/prometheus-exporter-operator/blob/master/LICENSE)
+  displayName: MARIN3R 3scale SaaS
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMzc1cHQiIGhlaWdodD0iMzc0Ljk5OTk5MXB0IiB2aWV3Qm94PSIwIDAgMzc1IDM3NC45OTk5OTEiIHZlcnNpb249IjEuMiI+CjxkZWZzPgo8Zz4KPHN5bWJvbCBvdmVyZmxvdz0idmlzaWJsZSIgaWQ9ImdseXBoMC0wIj4KPHBhdGggc3R5bGU9InN0cm9rZTpub25lOyIgZD0iIi8+Cjwvc3ltYm9sPgo8c3ltYm9sIG92ZXJmbG93PSJ2aXNpYmxlIiBpZD0iZ2x5cGgwLTEiPgo8cGF0aCBzdHlsZT0ic3Ryb2tlOm5vbmU7IiBkPSJNIDk1Ljk1MzEyNSAwIEwgODUuODkwNjI1IDAgTCA4NS44OTA2MjUgLTQyLjc5Njg3NSBMIDU0Ljk4NDM3NSAwIEwgNDkuODEyNSAwIEwgMTguOTA2MjUgLTQyLjc5Njg3NSBMIDE4LjkwNjI1IDAgTCA4LjgyODEyNSAwIEwgOC44MjgxMjUgLTYzLjMyODEyNSBMIDE2LjQyMTg3NSAtNjMuMzI4MTI1IEwgNTIuNDIxODc1IC0xMy41OTM3NSBMIDg4LjM1OTM3NSAtNjMuMzI4MTI1IEwgOTUuOTUzMTI1IC02My4zMjgxMjUgWiBNIDk1Ljk1MzEyNSAwICIvPgo8L3N5bWJvbD4KPHN5bWJvbCBvdmVyZmxvdz0idmlzaWJsZSIgaWQ9ImdseXBoMC0yIj4KPHBhdGggc3R5bGU9InN0cm9rZTpub25lOyIgZD0iTSA2MS45NTMxMjUgMCBMIDYuNjI1IDAgTCA2LjYyNSAtMTAuMDYyNSBMIDYxLjk1MzEyNSAtMTAuMDYyNSBDIDYzLjMzNTkzOCAtMTAuMDYyNSA2NC41MTk1MzEgLTEwLjU1NDY4OCA2NS41IC0xMS41NDY4NzUgQyA2Ni40ODgyODEgLTEyLjUzNTE1NiA2Ni45ODQzNzUgLTEzLjcyMjY1NiA2Ni45ODQzNzUgLTE1LjEwOTM3NSBMIDY2Ljk4NDM3NSAtMjEuNTkzNzUgQyA2Ni45ODQzNzUgLTIyLjk3NjU2MiA2Ni41MDc4MTIgLTI0LjE0ODQzOCA2NS41NjI1IC0yNS4xMDkzNzUgQyA2NC42MjUgLTI2LjA2NjQwNiA2My40Njg3NSAtMjYuNTcwMzEyIDYyLjA5Mzc1IC0yNi42MjUgTCAxNi42ODc1IC0yNi42MjUgTCAxNi42ODc1IC0zNi43MDMxMjUgTCA2Mi4wOTM3NSAtMzYuNzAzMTI1IEMgNjMuNDY4NzUgLTM2Ljc1MzkwNiA2NC42MjUgLTM3LjI1NzgxMiA2NS41NjI1IC0zOC4yMTg3NSBDIDY2LjUwNzgxMiAtMzkuMTc1NzgxIDY2Ljk4NDM3NSAtNDAuMzQ3NjU2IDY2Ljk4NDM3NSAtNDEuNzM0Mzc1IEwgNjYuOTg0Mzc1IC00OC4yNjU2MjUgQyA2Ni45ODQzNzUgLTQ5LjY0ODQzOCA2Ni40ODgyODEgLTUwLjgyODEyNSA2NS41IC01MS43OTY4NzUgQyA2NC41MTk1MzEgLTUyLjc2NTYyNSA2My4zMzU5MzggLTUzLjI1IDYxLjk1MzEyNSAtNTMuMjUgTCA2LjYyNSAtNTMuMjUgTCA2LjYyNSAtNjMuMzI4MTI1IEwgNjEuOTUzMTI1IC02My4zMjgxMjUgQyA2Ni4xMDkzNzUgLTYzLjMyODEyNSA2OS42NjQwNjIgLTYxLjg1MTU2MiA3Mi42MjUgLTU4LjkwNjI1IEMgNzUuNTgyMDMxIC01NS45NTcwMzEgNzcuMDYyNSAtNTIuNDEwMTU2IDc3LjA2MjUgLTQ4LjI2NTYyNSBMIDc3LjA2MjUgLTQxLjczNDM3NSBDIDc3LjA2MjUgLTM3Ljg3ODkwNiA3NS43ODEyNSAtMzQuNTE5NTMxIDczLjIxODc1IC0zMS42NTYyNSBDIDc1Ljc4MTI1IC0yOC44MzIwMzEgNzcuMDYyNSAtMjUuNDc2NTYyIDc3LjA2MjUgLTIxLjU5Mzc1IEwgNzcuMDYyNSAtMTUuMTA5Mzc1IEMgNzcuMDYyNSAtMTAuOTIxODc1IDc1LjU4MjAzMSAtNy4zNTE1NjIgNzIuNjI1IC00LjQwNjI1IEMgNjkuNjY0MDYyIC0xLjQ2ODc1IDY2LjEwOTM3NSAwIDYxLjk1MzEyNSAwIFogTSA2MS45NTMxMjUgMCAiLz4KPC9zeW1ib2w+CjxzeW1ib2wgb3ZlcmZsb3c9InZpc2libGUiIGlkPSJnbHlwaDAtMyI+CjxwYXRoIHN0eWxlPSJzdHJva2U6bm9uZTsiIGQ9Ik0gODQuMjk2ODc1IDAgTCA3NC4yMzQzNzUgMCBMIDc0LjIzNDM3NSAtMTcuODQzNzUgQyA3NC4yMzQzNzUgLTE5LjIyNjU2MiA3My43MzgyODEgLTIwLjQxMDE1NiA3Mi43NSAtMjEuMzkwNjI1IEMgNzEuNzU3ODEyIC0yMi4zNzg5MDYgNzAuNTc4MTI1IC0yMi44NzUgNjkuMjAzMTI1IC0yMi44NzUgTCAxOC45MDYyNSAtMjIuODc1IEwgMTguOTA2MjUgMCBMIDguODI4MTI1IDAgTCA4LjgyODEyNSAtNjMuMzI4MTI1IEwgNjkuMjAzMTI1IC02My4zMjgxMjUgQyA3My4zNDc2NTYgLTYzLjMyODEyNSA3Ni44OTg0MzggLTYxLjg1MTU2MiA3OS44NTkzNzUgLTU4LjkwNjI1IEMgODIuODE2NDA2IC01NS45NTcwMzEgODQuMjk2ODc1IC01Mi40MTAxNTYgODQuMjk2ODc1IC00OC4yNjU2MjUgTCA4NC4yOTY4NzUgLTM3Ljk4NDM3NSBDIDg0LjI5Njg3NSAtMzQuMDg1OTM4IDgzIC0zMC43MjY1NjIgODAuNDA2MjUgLTI3LjkwNjI1IEMgODMgLTI1LjA1MDc4MSA4NC4yOTY4NzUgLTIxLjY5NTMxMiA4NC4yOTY4NzUgLTE3Ljg0Mzc1IFogTSA2OS4yMDMxMjUgLTMyLjkzNzUgQyA3MC41NzgxMjUgLTMyLjkzNzUgNzEuNzU3ODEyIC0zMy40Mjk2ODggNzIuNzUgLTM0LjQyMTg3NSBDIDczLjczODI4MSAtMzUuNDEwMTU2IDc0LjIzNDM3NSAtMzYuNTk3NjU2IDc0LjIzNDM3NSAtMzcuOTg0Mzc1IEwgNzQuMjM0Mzc1IC00OC4yNjU2MjUgQyA3NC4yMzQzNzUgLTQ5LjY0ODQzOCA3My43MzgyODEgLTUwLjgzMjAzMSA3Mi43NSAtNTEuODEyNSBDIDcxLjc1NzgxMiAtNTIuODAwNzgxIDcwLjU3ODEyNSAtNTMuMjk2ODc1IDY5LjIwMzEyNSAtNTMuMjk2ODc1IEwgMTguOTA2MjUgLTUzLjI5Njg3NSBMIDE4LjkwNjI1IC0zMi45Mzc1IFogTSA2OS4yMDMxMjUgLTMyLjkzNzUgIi8+Cjwvc3ltYm9sPgo8L2c+CjwvZGVmcz4KPGcgaWQ9InN1cmZhY2UxIj4KPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjM3NSIgaGVpZ2h0PSIzNzQuOTk5OTkxIiBzdHlsZT0iZmlsbDpyZ2IoMTAwJSwxMDAlLDEwMCUpO2ZpbGwtb3BhY2l0eToxO3N0cm9rZTpub25lOyIvPgo8cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMzc1IiBoZWlnaHQ9IjM3NC45OTk5OTEiIHN0eWxlPSJmaWxsOnJnYigxMDAlLDEwMCUsMTAwJSk7ZmlsbC1vcGFjaXR5OjE7c3Ryb2tlOm5vbmU7Ii8+CjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIzNzUiIGhlaWdodD0iMzc0Ljk5OTk5MSIgc3R5bGU9ImZpbGw6cmdiKDEwMCUsMTAwJSwxMDAlKTtmaWxsLW9wYWNpdHk6MTtzdHJva2U6bm9uZTsiLz4KPHBhdGggc3R5bGU9IiBzdHJva2U6bm9uZTtmaWxsLXJ1bGU6bm9uemVybztmaWxsOnJnYigwJSwwJSwwJSk7ZmlsbC1vcGFjaXR5OjE7IiBkPSJNIDE4Ny41IDE5LjMyODEyNSBDIDE4NC43NDYwOTQgMTkuMzI4MTI1IDE4MS45OTYwOTQgMTkuMzk4NDM4IDE3OS4yNSAxOS41MzEyNSBDIDE3Ni41IDE5LjY2Nzk2OSAxNzMuNzUzOTA2IDE5Ljg3MTA5NCAxNzEuMDE1NjI1IDIwLjE0MDYyNSBDIDE2OC4yNzczNDQgMjAuNDEwMTU2IDE2NS41NDY4NzUgMjAuNzQ2MDk0IDE2Mi44MjQyMTkgMjEuMTQ4NDM4IEMgMTYwLjEwMTU2MiAyMS41NTQ2ODggMTU3LjM5MDYyNSAyMi4wMjM0MzggMTU0LjY5MTQwNiAyMi41NjI1IEMgMTUxLjk5MjE4OCAyMy4wOTc2NTYgMTQ5LjMwODU5NCAyMy42OTkyMTkgMTQ2LjYzNjcxOSAyNC4zNzEwOTQgQyAxNDMuOTY4NzUgMjUuMDM5MDYyIDE0MS4zMTY0MDYgMjUuNzczNDM4IDEzOC42ODM1OTQgMjYuNTcwMzEyIEMgMTM2LjA1MDc4MSAyNy4zNzEwOTQgMTMzLjQzNzUgMjguMjM0Mzc1IDEzMC44NDM3NSAyOS4xNjAxNTYgQyAxMjguMjUzOTA2IDMwLjA4NTkzOCAxMjUuNjg3NSAzMS4wNzgxMjUgMTIzLjE0NDUzMSAzMi4xMzI4MTIgQyAxMjAuNjAxNTYyIDMzLjE4MzU5NCAxMTguMDg1OTM4IDM0LjMwMDc4MSAxMTUuNTk3NjU2IDM1LjQ3NjU2MiBDIDExMy4xMDkzNzUgMzYuNjUyMzQ0IDExMC42NTIzNDQgMzcuODkwNjI1IDEwOC4yMjY1NjIgMzkuMTg3NSBDIDEwNS43OTY4NzUgNDAuNDg0Mzc1IDEwMy40MDIzNDQgNDEuODM5ODQ0IDEwMS4wNDI5NjkgNDMuMjUzOTA2IEMgOTguNjgzNTk0IDQ0LjY3MTg3NSA5Ni4zNTkzNzUgNDYuMTQ0NTMxIDk0LjA3MDMxMiA0Ny42NzE4NzUgQyA5MS43ODEyNSA0OS4xOTkyMTkgODkuNTMxMjUgNTAuNzg1MTU2IDg3LjMyMDMxMiA1Mi40MjU3ODEgQyA4NS4xMDkzNzUgNTQuMDYyNSA4Mi45NDE0MDYgNTUuNzU3ODEyIDgwLjgxMjUgNTcuNTAzOTA2IEMgNzguNjg3NSA1OS4yNSA3Ni42MDE1NjIgNjEuMDQ2ODc1IDc0LjU2MjUgNjIuODk0NTMxIEMgNzIuNTIzNDM4IDY0Ljc0MjE4OCA3MC41MzEyNSA2Ni42NDA2MjUgNjguNTg1OTM4IDY4LjU4NTkzOCBDIDY2LjY0MDYyNSA3MC41MzEyNSA2NC43NDIxODggNzIuNTIzNDM4IDYyLjg5NDUzMSA3NC41NjI1IEMgNjEuMDQ2ODc1IDc2LjYwMTU2MiA1OS4yNSA3OC42ODc1IDU3LjUwMzkwNiA4MC44MTI1IEMgNTUuNzU3ODEyIDgyLjk0MTQwNiA1NC4wNjI1IDg1LjEwOTM3NSA1Mi40MjU3ODEgODcuMzIwMzEyIEMgNTAuNzg1MTU2IDg5LjUzMTI1IDQ5LjE5OTIxOSA5MS43ODEyNSA0Ny42NzE4NzUgOTQuMDcwMzEyIEMgNDYuMTQ0NTMxIDk2LjM1OTM3NSA0NC42NzE4NzUgOTguNjgzNTk0IDQzLjI1MzkwNiAxMDEuMDQyOTY5IEMgNDEuODM5ODQ0IDEwMy40MDIzNDQgNDAuNDg0Mzc1IDEwNS43OTY4NzUgMzkuMTg3NSAxMDguMjI2NTYyIEMgMzcuODkwNjI1IDExMC42NTIzNDQgMzYuNjUyMzQ0IDExMy4xMDkzNzUgMzUuNDc2NTYyIDExNS41OTc2NTYgQyAzNC4zMDA3ODEgMTE4LjA4NTkzOCAzMy4xODM1OTQgMTIwLjYwMTU2MiAzMi4xMzI4MTIgMTIzLjE0NDUzMSBDIDMxLjA3ODEyNSAxMjUuNjg3NSAzMC4wODU5MzggMTI4LjI1MzkwNiAyOS4xNjAxNTYgMTMwLjg0Mzc1IEMgMjguMjM0Mzc1IDEzMy40Mzc1IDI3LjM3MTA5NCAxMzYuMDUwNzgxIDI2LjU3MDMxMiAxMzguNjgzNTk0IEMgMjUuNzczNDM4IDE0MS4zMTY0MDYgMjUuMDM5MDYyIDE0My45Njg3NSAyNC4zNzEwOTQgMTQ2LjYzNjcxOSBDIDIzLjY5OTIxOSAxNDkuMzA4NTk0IDIzLjA5NzY1NiAxNTEuOTkyMTg4IDIyLjU2MjUgMTU0LjY5MTQwNiBDIDIyLjAyMzQzOCAxNTcuMzkwNjI1IDIxLjU1NDY4OCAxNjAuMTAxNTYyIDIxLjE0ODQzOCAxNjIuODI0MjE5IEMgMjAuNzQ2MDk0IDE2NS41NDY4NzUgMjAuNDEwMTU2IDE2OC4yNzczNDQgMjAuMTQwNjI1IDE3MS4wMTU2MjUgQyAxOS44NzEwOTQgMTczLjc1MzkwNiAxOS42Njc5NjkgMTc2LjUgMTkuNTMxMjUgMTc5LjI1IEMgMTkuMzk4NDM4IDE4MS45OTYwOTQgMTkuMzI4MTI1IDE4NC43NDYwOTQgMTkuMzI4MTI1IDE4Ny41IEMgMTkuMzI4MTI1IDE5MC4yNTM5MDYgMTkuMzk4NDM4IDE5My4wMDM5MDYgMTkuNTMxMjUgMTk1Ljc1IEMgMTkuNjY3OTY5IDE5OC41IDE5Ljg3MTA5NCAyMDEuMjQ2MDk0IDIwLjE0MDYyNSAyMDMuOTg0Mzc1IEMgMjAuNDEwMTU2IDIwNi43MjI2NTYgMjAuNzQ2MDk0IDIwOS40NTMxMjUgMjEuMTQ4NDM4IDIxMi4xNzU3ODEgQyAyMS41NTQ2ODggMjE0Ljg5ODQzOCAyMi4wMjM0MzggMjE3LjYwOTM3NSAyMi41NjI1IDIyMC4zMDg1OTQgQyAyMy4wOTc2NTYgMjIzLjAwNzgxMiAyMy42OTkyMTkgMjI1LjY5MTQwNiAyNC4zNzEwOTQgMjI4LjM2MzI4MSBDIDI1LjAzOTA2MiAyMzEuMDMxMjUgMjUuNzczNDM4IDIzMy42ODM1OTQgMjYuNTcwMzEyIDIzNi4zMTY0MDYgQyAyNy4zNzEwOTQgMjM4Ljk0OTIxOSAyOC4yMzQzNzUgMjQxLjU2MjUgMjkuMTYwMTU2IDI0NC4xNTYyNSBDIDMwLjA4NTkzOCAyNDYuNzQ2MDk0IDMxLjA3ODEyNSAyNDkuMzEyNSAzMi4xMzI4MTIgMjUxLjg1NTQ2OSBDIDMzLjE4MzU5NCAyNTQuMzk4NDM4IDM0LjMwMDc4MSAyNTYuOTE0MDYyIDM1LjQ3NjU2MiAyNTkuNDAyMzQ0IEMgMzYuNjUyMzQ0IDI2MS44OTA2MjUgMzcuODkwNjI1IDI2NC4zNDc2NTYgMzkuMTg3NSAyNjYuNzczNDM4IEMgNDAuNDg0Mzc1IDI2OS4yMDMxMjUgNDEuODM5ODQ0IDI3MS41OTc2NTYgNDMuMjUzOTA2IDI3My45NTcwMzEgQyA0NC42NzE4NzUgMjc2LjMxNjQwNiA0Ni4xNDQ1MzEgMjc4LjY0MDYyNSA0Ny42NzE4NzUgMjgwLjkyOTY4OCBDIDQ5LjE5OTIxOSAyODMuMjE4NzUgNTAuNzg1MTU2IDI4NS40Njg3NSA1Mi40MjU3ODEgMjg3LjY3OTY4OCBDIDU0LjA2MjUgMjg5Ljg5MDYyNSA1NS43NTc4MTIgMjkyLjA1ODU5NCA1Ny41MDM5MDYgMjk0LjE4NzUgQyA1OS4yNSAyOTYuMzEyNSA2MS4wNDY4NzUgMjk4LjM5ODQzOCA2Mi44OTQ1MzEgMzAwLjQzNzUgQyA2NC43NDIxODggMzAyLjQ3NjU2MiA2Ni42NDA2MjUgMzA0LjQ2ODc1IDY4LjU4NTkzOCAzMDYuNDE0MDYyIEMgNzAuNTMxMjUgMzA4LjM1OTM3NSA3Mi41MjM0MzggMzEwLjI1NzgxMiA3NC41NjI1IDMxMi4xMDU0NjkgQyA3Ni42MDE1NjIgMzEzLjk1MzEyNSA3OC42ODc1IDMxNS43NSA4MC44MTI1IDMxNy40OTYwOTQgQyA4Mi45NDE0MDYgMzE5LjI0MjE4OCA4NS4xMDkzNzUgMzIwLjkzNzUgODcuMzIwMzEyIDMyMi41NzQyMTkgQyA4OS41MzEyNSAzMjQuMjE0ODQ0IDkxLjc4MTI1IDMyNS44MDA3ODEgOTQuMDcwMzEyIDMyNy4zMjgxMjUgQyA5Ni4zNTkzNzUgMzI4Ljg1NTQ2OSA5OC42ODM1OTQgMzMwLjMyODEyNSAxMDEuMDQyOTY5IDMzMS43NDYwOTQgQyAxMDMuNDAyMzQ0IDMzMy4xNjAxNTYgMTA1Ljc5Njg3NSAzMzQuNTE1NjI1IDEwOC4yMjY1NjIgMzM1LjgxMjUgQyAxMTAuNjUyMzQ0IDMzNy4xMDkzNzUgMTEzLjEwOTM3NSAzMzguMzQ3NjU2IDExNS41OTc2NTYgMzM5LjUyMzQzOCBDIDExOC4wODU5MzggMzQwLjY5OTIxOSAxMjAuNjAxNTYyIDM0MS44MTY0MDYgMTIzLjE0NDUzMSAzNDIuODY3MTg4IEMgMTI1LjY4NzUgMzQzLjkyMTg3NSAxMjguMjUzOTA2IDM0NC45MTQwNjIgMTMwLjg0Mzc1IDM0NS44Mzk4NDQgQyAxMzMuNDM3NSAzNDYuNzY1NjI1IDEzNi4wNTA3ODEgMzQ3LjYyODkwNiAxMzguNjgzNTk0IDM0OC40Mjk2ODggQyAxNDEuMzE2NDA2IDM0OS4yMjY1NjIgMTQzLjk2ODc1IDM0OS45NjA5MzggMTQ2LjYzNjcxOSAzNTAuNjI4OTA2IEMgMTQ5LjMwODU5NCAzNTEuMzAwNzgxIDE1MS45OTIxODggMzUxLjkwMjM0NCAxNTQuNjkxNDA2IDM1Mi40Mzc1IEMgMTU3LjM5MDYyNSAzNTIuOTc2NTYyIDE2MC4xMDE1NjIgMzUzLjQ0NTMxMiAxNjIuODI0MjE5IDM1My44NTE1NjIgQyAxNjUuNTQ2ODc1IDM1NC4yNTM5MDYgMTY4LjI3NzM0NCAzNTQuNTg5ODQ0IDE3MS4wMTU2MjUgMzU0Ljg1OTM3NSBDIDE3My43NTM5MDYgMzU1LjEyODkwNiAxNzYuNSAzNTUuMzMyMDMxIDE3OS4yNSAzNTUuNDY4NzUgQyAxODEuOTk2MDk0IDM1NS42MDE1NjIgMTg0Ljc0NjA5NCAzNTUuNjcxODc1IDE4Ny41IDM1NS42NzE4NzUgQyAxOTAuMjUzOTA2IDM1NS42NzE4NzUgMTkzLjAwMzkwNiAzNTUuNjAxNTYyIDE5NS43NSAzNTUuNDY4NzUgQyAxOTguNSAzNTUuMzMyMDMxIDIwMS4yNDYwOTQgMzU1LjEyODkwNiAyMDMuOTg0Mzc1IDM1NC44NTkzNzUgQyAyMDYuNzIyNjU2IDM1NC41ODk4NDQgMjA5LjQ1MzEyNSAzNTQuMjUzOTA2IDIxMi4xNzU3ODEgMzUzLjg1MTU2MiBDIDIxNC44OTg0MzggMzUzLjQ0NTMxMiAyMTcuNjA5Mzc1IDM1Mi45NzY1NjIgMjIwLjMwODU5NCAzNTIuNDM3NSBDIDIyMy4wMDc4MTIgMzUxLjkwMjM0NCAyMjUuNjkxNDA2IDM1MS4zMDA3ODEgMjI4LjM2MzI4MSAzNTAuNjI4OTA2IEMgMjMxLjAzMTI1IDM0OS45NjA5MzggMjMzLjY4MzU5NCAzNDkuMjI2NTYyIDIzNi4zMTY0MDYgMzQ4LjQyOTY4OCBDIDIzOC45NDkyMTkgMzQ3LjYyODkwNiAyNDEuNTYyNSAzNDYuNzY1NjI1IDI0NC4xNTYyNSAzNDUuODM5ODQ0IEMgMjQ2Ljc0NjA5NCAzNDQuOTE0MDYyIDI0OS4zMTI1IDM0My45MjE4NzUgMjUxLjg1NTQ2OSAzNDIuODY3MTg4IEMgMjU0LjM5ODQzOCAzNDEuODE2NDA2IDI1Ni45MTQwNjIgMzQwLjY5OTIxOSAyNTkuNDAyMzQ0IDMzOS41MjM0MzggQyAyNjEuODkwNjI1IDMzOC4zNDc2NTYgMjY0LjM0NzY1NiAzMzcuMTA5Mzc1IDI2Ni43NzM0MzggMzM1LjgxMjUgQyAyNjkuMjAzMTI1IDMzNC41MTU2MjUgMjcxLjU5NzY1NiAzMzMuMTYwMTU2IDI3My45NTcwMzEgMzMxLjc0NjA5NCBDIDI3Ni4zMTY0MDYgMzMwLjMyODEyNSAyNzguNjQwNjI1IDMyOC44NTU0NjkgMjgwLjkyOTY4OCAzMjcuMzI4MTI1IEMgMjgzLjIxODc1IDMyNS44MDA3ODEgMjg1LjQ2ODc1IDMyNC4yMTQ4NDQgMjg3LjY3OTY4OCAzMjIuNTc0MjE5IEMgMjg5Ljg5MDYyNSAzMjAuOTM3NSAyOTIuMDU4NTk0IDMxOS4yNDIxODggMjk0LjE4NzUgMzE3LjQ5NjA5NCBDIDI5Ni4zMTI1IDMxNS43NSAyOTguMzk4NDM4IDMxMy45NTMxMjUgMzAwLjQzNzUgMzEyLjEwNTQ2OSBDIDMwMi40NzY1NjIgMzEwLjI1NzgxMiAzMDQuNDY4NzUgMzA4LjM1OTM3NSAzMDYuNDE0MDYyIDMwNi40MTQwNjIgQyAzMDguMzU5Mzc1IDMwNC40Njg3NSAzMTAuMjU3ODEyIDMwMi40NzY1NjIgMzEyLjEwNTQ2OSAzMDAuNDM3NSBDIDMxMy45NTMxMjUgMjk4LjM5ODQzOCAzMTUuNzUgMjk2LjMxMjUgMzE3LjQ5NjA5NCAyOTQuMTg3NSBDIDMxOS4yNDIxODggMjkyLjA1ODU5NCAzMjAuOTM3NSAyODkuODkwNjI1IDMyMi41NzQyMTkgMjg3LjY3OTY4OCBDIDMyNC4yMTQ4NDQgMjg1LjQ2ODc1IDMyNS44MDA3ODEgMjgzLjIxODc1IDMyNy4zMjgxMjUgMjgwLjkyOTY4OCBDIDMyOC44NTU0NjkgMjc4LjY0MDYyNSAzMzAuMzI4MTI1IDI3Ni4zMTY0MDYgMzMxLjc0NjA5NCAyNzMuOTU3MDMxIEMgMzMzLjE2MDE1NiAyNzEuNTk3NjU2IDMzNC41MTU2MjUgMjY5LjIwMzEyNSAzMzUuODEyNSAyNjYuNzczNDM4IEMgMzM3LjEwOTM3NSAyNjQuMzQ3NjU2IDMzOC4zNDc2NTYgMjYxLjg5MDYyNSAzMzkuNTIzNDM4IDI1OS40MDIzNDQgQyAzNDAuNjk5MjE5IDI1Ni45MTQwNjIgMzQxLjgxNjQwNiAyNTQuMzk4NDM4IDM0Mi44NjcxODggMjUxLjg1NTQ2OSBDIDM0My45MjE4NzUgMjQ5LjMxMjUgMzQ0LjkxNDA2MiAyNDYuNzQ2MDk0IDM0NS44Mzk4NDQgMjQ0LjE1NjI1IEMgMzQ2Ljc2NTYyNSAyNDEuNTYyNSAzNDcuNjI4OTA2IDIzOC45NDkyMTkgMzQ4LjQyOTY4OCAyMzYuMzE2NDA2IEMgMzQ5LjIyNjU2MiAyMzMuNjgzNTk0IDM0OS45NjA5MzggMjMxLjAzMTI1IDM1MC42Mjg5MDYgMjI4LjM2MzI4MSBDIDM1MS4zMDA3ODEgMjI1LjY5MTQwNiAzNTEuOTAyMzQ0IDIyMy4wMDc4MTIgMzUyLjQzNzUgMjIwLjMwODU5NCBDIDM1Mi45NzY1NjIgMjE3LjYwOTM3NSAzNTMuNDQ1MzEyIDIxNC44OTg0MzggMzUzLjg1MTU2MiAyMTIuMTc1NzgxIEMgMzU0LjI1MzkwNiAyMDkuNDUzMTI1IDM1NC41ODk4NDQgMjA2LjcyMjY1NiAzNTQuODU5Mzc1IDIwMy45ODQzNzUgQyAzNTUuMTI4OTA2IDIwMS4yNDYwOTQgMzU1LjMzMjAzMSAxOTguNSAzNTUuNDY4NzUgMTk1Ljc1IEMgMzU1LjYwMTU2MiAxOTMuMDAzOTA2IDM1NS42NzE4NzUgMTkwLjI1MzkwNiAzNTUuNjcxODc1IDE4Ny41IEMgMzU1LjY3MTg3NSAxODQuNzQ2MDk0IDM1NS42MDE1NjIgMTgxLjk5NjA5NCAzNTUuNDY4NzUgMTc5LjI1IEMgMzU1LjMzMjAzMSAxNzYuNSAzNTUuMTI4OTA2IDE3My43NTM5MDYgMzU0Ljg1OTM3NSAxNzEuMDE1NjI1IEMgMzU0LjU4OTg0NCAxNjguMjc3MzQ0IDM1NC4yNTM5MDYgMTY1LjU0Njg3NSAzNTMuODUxNTYyIDE2Mi44MjQyMTkgQyAzNTMuNDQ1MzEyIDE2MC4xMDE1NjIgMzUyLjk3NjU2MiAxNTcuMzkwNjI1IDM1Mi40Mzc1IDE1NC42OTE0MDYgQyAzNTEuOTAyMzQ0IDE1MS45OTIxODggMzUxLjMwMDc4MSAxNDkuMzA4NTk0IDM1MC42Mjg5MDYgMTQ2LjYzNjcxOSBDIDM0OS45NjA5MzggMTQzLjk2ODc1IDM0OS4yMjY1NjIgMTQxLjMxNjQwNiAzNDguNDI5Njg4IDEzOC42ODM1OTQgQyAzNDcuNjI4OTA2IDEzNi4wNTA3ODEgMzQ2Ljc2NTYyNSAxMzMuNDM3NSAzNDUuODM5ODQ0IDEzMC44NDM3NSBDIDM0NC45MTQwNjIgMTI4LjI1MzkwNiAzNDMuOTIxODc1IDEyNS42ODc1IDM0Mi44NjcxODggMTIzLjE0NDUzMSBDIDM0MS44MTY0MDYgMTIwLjYwMTU2MiAzNDAuNjk5MjE5IDExOC4wODU5MzggMzM5LjUyMzQzOCAxMTUuNTk3NjU2IEMgMzM4LjM0NzY1NiAxMTMuMTA5Mzc1IDMzNy4xMDkzNzUgMTEwLjY1MjM0NCAzMzUuODEyNSAxMDguMjI2NTYyIEMgMzM0LjUxNTYyNSAxMDUuNzk2ODc1IDMzMy4xNjAxNTYgMTAzLjQwMjM0NCAzMzEuNzQ2MDk0IDEwMS4wNDI5NjkgQyAzMzAuMzI4MTI1IDk4LjY4MzU5NCAzMjguODU1NDY5IDk2LjM1OTM3NSAzMjcuMzI4MTI1IDk0LjA3MDMxMiBDIDMyNS44MDA3ODEgOTEuNzgxMjUgMzI0LjIxNDg0NCA4OS41MzEyNSAzMjIuNTc0MjE5IDg3LjMyMDMxMiBDIDMyMC45Mzc1IDg1LjEwOTM3NSAzMTkuMjQyMTg4IDgyLjk0MTQwNiAzMTcuNDk2MDk0IDgwLjgxMjUgQyAzMTUuNzUgNzguNjg3NSAzMTMuOTUzMTI1IDc2LjYwMTU2MiAzMTIuMTA1NDY5IDc0LjU2MjUgQyAzMTAuMjU3ODEyIDcyLjUyMzQzOCAzMDguMzU5Mzc1IDcwLjUzMTI1IDMwNi40MTQwNjIgNjguNTg1OTM4IEMgMzA0LjQ2ODc1IDY2LjY0MDYyNSAzMDIuNDc2NTYyIDY0Ljc0MjE4OCAzMDAuNDM3NSA2Mi44OTQ1MzEgQyAyOTguMzk4NDM4IDYxLjA0Njg3NSAyOTYuMzEyNSA1OS4yNSAyOTQuMTg3NSA1Ny41MDM5MDYgQyAyOTIuMDU4NTk0IDU1Ljc1NzgxMiAyODkuODkwNjI1IDU0LjA2MjUgMjg3LjY3OTY4OCA1Mi40MjU3ODEgQyAyODUuNDY4NzUgNTAuNzg1MTU2IDI4My4yMTg3NSA0OS4xOTkyMTkgMjgwLjkyOTY4OCA0Ny42NzE4NzUgQyAyNzguNjQwNjI1IDQ2LjE0NDUzMSAyNzYuMzE2NDA2IDQ0LjY3MTg3NSAyNzMuOTU3MDMxIDQzLjI1MzkwNiBDIDI3MS41OTc2NTYgNDEuODM5ODQ0IDI2OS4yMDMxMjUgNDAuNDg0Mzc1IDI2Ni43NzM0MzggMzkuMTg3NSBDIDI2NC4zNDc2NTYgMzcuODkwNjI1IDI2MS44OTA2MjUgMzYuNjUyMzQ0IDI1OS40MDIzNDQgMzUuNDc2NTYyIEMgMjU2LjkxNDA2MiAzNC4zMDA3ODEgMjU0LjM5ODQzOCAzMy4xODM1OTQgMjUxLjg1NTQ2OSAzMi4xMzI4MTIgQyAyNDkuMzEyNSAzMS4wNzgxMjUgMjQ2Ljc0NjA5NCAzMC4wODU5MzggMjQ0LjE1NjI1IDI5LjE2MDE1NiBDIDI0MS41NjI1IDI4LjIzNDM3NSAyMzguOTQ5MjE5IDI3LjM3MTA5NCAyMzYuMzE2NDA2IDI2LjU3MDMxMiBDIDIzMy42ODM1OTQgMjUuNzczNDM4IDIzMS4wMzEyNSAyNS4wMzkwNjIgMjI4LjM2MzI4MSAyNC4zNzEwOTQgQyAyMjUuNjkxNDA2IDIzLjY5OTIxOSAyMjMuMDA3ODEyIDIzLjA5NzY1NiAyMjAuMzA4NTk0IDIyLjU2MjUgQyAyMTcuNjA5Mzc1IDIyLjAyMzQzOCAyMTQuODk4NDM4IDIxLjU1NDY4OCAyMTIuMTc1NzgxIDIxLjE0ODQzOCBDIDIwOS40NTMxMjUgMjAuNzQ2MDk0IDIwNi43MjI2NTYgMjAuNDEwMTU2IDIwMy45ODQzNzUgMjAuMTQwNjI1IEMgMjAxLjI0NjA5NCAxOS44NzEwOTQgMTk4LjUgMTkuNjY3OTY5IDE5NS43NSAxOS41MzEyNSBDIDE5My4wMDM5MDYgMTkuMzk4NDM4IDE5MC4yNTM5MDYgMTkuMzI4MTI1IDE4Ny41IDE5LjMyODEyNSBaIE0gMTg3LjUgMTkuMzI4MTI1ICIvPgo8ZyBzdHlsZT0iZmlsbDpyZ2IoMTAwJSwxMDAlLDEwMCUpO2ZpbGwtb3BhY2l0eToxOyI+CiAgPHVzZSB4bGluazpocmVmPSIjZ2x5cGgwLTEiIHg9IjQ3Ljg0NjE1NCIgeT0iMjE1LjQ3MTcyOCIvPgo8L2c+CjxnIHN0eWxlPSJmaWxsOnJnYigxMDAlLDU2Ljg1ODgyNiUsMzAuMTk4NjY5JSk7ZmlsbC1vcGFjaXR5OjE7Ij4KICA8dXNlIHhsaW5rOmhyZWY9IiNnbHlwaDAtMiIgeD0iMTUyLjYwMzYwNyIgeT0iMjE1LjQ3MTcyOCIvPgo8L2c+CjxnIHN0eWxlPSJmaWxsOnJnYigxMDAlLDEwMCUsMTAwJSk7ZmlsbC1vcGFjaXR5OjE7Ij4KICA8dXNlIHhsaW5rOmhyZWY9IiNnbHlwaDAtMyIgeD0iMjM2LjI0NTY3MyIgeT0iMjE1LjQ3MTcyOCIvPgo8L2c+CjwvZz4KPC9zdmc+Cg==
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: marin3r-controller-manager
+      deployments:
+        - name: marin3r-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - args:
+                      - --secure-listen-address=0.0.0.0:8443
+                      - --upstream=http://127.0.0.1:8080/
+                      - --logtostderr=true
+                      - --v=10
+                    image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+                    name: kube-rbac-proxy
+                    ports:
+                      - containerPort: 8443
+                        name: https
+                    resources: {}
+                  - args:
+                      - operator
+                      - --metrics-addr=127.0.0.1:8080
+                      - --enable-leader-election
+                    command:
+                      - /manager
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                    image: quay.io/3scale/marin3r:v0.7.0-alpha6
+                    name: manager
+                    resources:
+                      limits:
+                        cpu: 300m
+                        memory: 300Mi
+                      requests:
+                        cpu: 100m
+                        memory: 100Mi
+                serviceAccountName: marin3r-controller-manager
+                terminationGracePeriodSeconds: 10
+        - name: marin3r-controller-webhook
+          spec:
+            replicas: 2
+            selector:
+              matchLabels:
+                control-plane: controller-webhook
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  control-plane: controller-webhook
+              spec:
+                containers:
+                  - args:
+                      - webhook
+                      - --tls-dir=/apiserver.local.config/certificates
+                      - --tls-cert-name=apiserver.crt
+                      - --tls-key-name=apiserver.key
+                    command:
+                      - /manager
+                    image: quay.io/3scale/marin3r:v0.7.0-alpha6
+                    name: webhook
+                    ports:
+                      - containerPort: 9443
+                        name: webhook-server
+                        protocol: TCP
+                    resources: {}
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps/status
+              verbs:
+                - get
+                - update
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - services
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - envoybootstraps
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - envoybootstraps/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - envoyconfigrevisions
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - envoyconfigrevisions/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - envoyconfigs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - marin3r.3scale.net
+              resources:
+                - envoyconfigs/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - operator.marin3r.3scale.net
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - operator.marin3r.3scale.net
+              resources:
+                - discoveryservicecertificates
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.marin3r.3scale.net
+              resources:
+                - discoveryservicecertificates/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - rolebindings
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - watch
+          serviceAccountName: marin3r-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - envoy
+    - discovery
+    - controlplane
+    - proxy
+    - sidecar
+    - xds
+    - network
+  links:
+    - name: GitHub
+      url: https://github.com/3scale/marin3r
+  maintainers:
+    - email: 3scale-operations+marin3r@redhat.com
+      name: 3scale Operations Team
+  maturity: alpha
+  provider:
+    name: threescale
+  replaces: marin3r-threescale.v0.7.0-alpha5
+  version: 0.7.0-alpha6
+  webhookdefinitions:
+    - admissionReviewVersions:
+        - v1beta1
+      containerPort: 9443
+      deploymentName: marin3r-controller-webhook
+      failurePolicy: Fail
+      generateName: sidecar-injector.marin3r.3scale.net
+      matchPolicy: Equivalent
+      objectSelector:
+        matchLabels:
+          marin3r.3scale.net/status: enabled
+      reinvocationPolicy: Never
+      rules:
+        - apiGroups:
+            - ""
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+          resources:
+            - pods
+          scope: Namespaced
+      sideEffects: None
+      timeoutSeconds: 5
+      type: MutatingAdmissionWebhook
+      webhookPath: /pod-v1-mutate

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/operator.marin3r.3scale.net_discoveryservicecertificates.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/operator.marin3r.3scale.net_discoveryservicecertificates.yaml
@@ -1,0 +1,139 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: discoveryservicecertificates.operator.marin3r.3scale.net
+spec:
+  group: operator.marin3r.3scale.net
+  names:
+    kind: DiscoveryServiceCertificate
+    listKind: DiscoveryServiceCertificateList
+    plural: discoveryservicecertificates
+    singular: discoveryservicecertificate
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: DiscoveryServiceCertificate is used to create certificates, either self-signed or by using a cert-manager CA issuer. This object is used by the DiscoveryService controller to create the required certificates for the different components of the discovery service. Direct use of DiscoveryServiceCertificate objects is discouraged.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DiscoveryServiceCertificateSpec defines the desired state of DiscoveryServiceCertificate
+          properties:
+            certificateRenewalNotification:
+              description: CertificateRenewalConfig configures the certificate renewal process. If unset default behavior is to renew the certificate but not notify of renewals.
+              properties:
+                enabled:
+                  description: Enabled is a flag to enable or disable renewal of the certificate
+                  type: boolean
+              required:
+              - enabled
+              type: object
+            commonName:
+              description: CommonName is the CommonName of the certificate
+              type: string
+            hosts:
+              description: Hosts is the list of hosts the certificate is valid for. Only use when 'IsServerCertificate' is true. If unset, the CommonName field will be used to populate the valid hosts of the certificate.
+              items:
+                type: string
+              type: array
+            isCA:
+              description: IsCA is a boolean specifying that the certificate is a CA
+              type: boolean
+            secretRef:
+              description: SecretRef is a reference to the secret that will hold the certificate and the private key.
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret name must be unique.
+                  type: string
+              type: object
+            server:
+              description: IsServerCertificate is a boolean specifying if the certificate should be issued with server auth usage enabled
+              type: boolean
+            signer:
+              description: Signer specifies  the signer to use to create this certificate. Supported signers are CertManager and SelfSigned.
+              properties:
+                caSigned:
+                  description: CASigned holds specific configuration for the CASigned signer
+                  properties:
+                    caSecretRef:
+                      description: A reference to a Secret containing the CA
+                      properties:
+                        name:
+                          description: Name is unique within a namespace to reference a secret resource.
+                          type: string
+                        namespace:
+                          description: Namespace defines the space within which the secret name must be unique.
+                          type: string
+                      type: object
+                  required:
+                  - caSecretRef
+                  type: object
+                selfSigned:
+                  description: SelfSigned holds specific configuration for the SelfSigned signer
+                  type: object
+              type: object
+            validFor:
+              description: ValidFor specifies the validity of the certificate in seconds
+              format: int64
+              type: integer
+          required:
+          - commonName
+          - secretRef
+          - signer
+          - validFor
+          type: object
+        status:
+          description: DiscoveryServiceCertificateStatus defines the observed state of DiscoveryServiceCertificate
+          properties:
+            conditions:
+              description: Conditions represent the latest available observations of an object's state
+              items:
+                description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/operator.marin3r.3scale.net_discoveryservices.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha6/manifests/operator.marin3r.3scale.net_discoveryservices.yaml
@@ -1,0 +1,148 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: discoveryservices.operator.marin3r.3scale.net
+spec:
+  group: operator.marin3r.3scale.net
+  names:
+    kind: DiscoveryService
+    listKind: DiscoveryServiceList
+    plural: discoveryservices
+    singular: discoveryservice
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: DiscoveryService represents an envoy discovery service server. Currently only one DiscoveryService per cluster is supported.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DiscoveryServiceSpec defines the desired state of DiscoveryService
+          properties:
+            ServiceConfig:
+              description: ServiceConfig configures the way the DiscoveryService endpoints are exposed
+              properties:
+                name:
+                  type: string
+                type:
+                  description: ServiceType is an enum with the available discovery service Service types
+                  type: string
+              type: object
+            debug:
+              description: Debug enables debugging log level for the discovery service controllers. It is safe to use since secret data is never shown in the logs.
+              type: boolean
+            image:
+              description: Image holds the image to use for the discovery service Deployment
+              type: string
+            metricsPort:
+              description: MetricsPort is the port where metrics are served. Defaults to 8383.
+              format: int32
+              type: integer
+            pkiConfg:
+              description: PKIConfig has configuration for the PKI that marin3r manages for the different certificates it requires
+              properties:
+                rootCertificateAuthority:
+                  description: CertificateOptions specifies options to generate the server certificate used both for the xDS server and the mutating webhook server.
+                  properties:
+                    duration:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - duration
+                  - secretName
+                  type: object
+                serverCertificate:
+                  description: CertificateOptions specifies options to generate the server certificate used both for the xDS server and the mutating webhook server.
+                  properties:
+                    duration:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - duration
+                  - secretName
+                  type: object
+              required:
+              - rootCertificateAuthority
+              - serverCertificate
+              type: object
+            resources:
+              description: Resources holds the Resource Requirements to use for the discovery service Deployment. When not set it defaults to no resource requests nor limits. CPU and Memory resources are supported.
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            xdsPort:
+              description: XdsServerPort is the port where the xDS server listens. Defaults to 18000.
+              format: int32
+              type: integer
+          type: object
+        status:
+          description: DiscoveryServiceStatus defines the observed state of DiscoveryService
+          properties:
+            conditions:
+              description: Conditions represent the latest available observations of an object's state
+              items:
+                description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha6/metadata/annotations.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha6/metadata/annotations.yaml
@@ -1,0 +1,11 @@
+annotations:
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: marin3r-threescale
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.1.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/olm-bundle-catalog/marin3r/v0.7.0-alpha6/tests/scorecard/config.yaml
+++ b/olm-bundle-catalog/marin3r/v0.7.0-alpha6/tests/scorecard/config.yaml
@@ -1,0 +1,49 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.1.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.1.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.1.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.1.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.1.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.1.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test


### PR DESCRIPTION
The initial approach I took for the automatic management of our SaaS operators catalog is:

* All generation is based in using an specific tag from the source repository. This will usually be a semver style version.
* The source repo is cloned in /tmp using the specific tag, and from there the `bundle/` directory is copied and modified appropriately.
* Each operator has its own Makefile with its own modifications and its own publication targets that reuse the common build targets from the main Makefile. See `marin3r.mk` for an example.
* For the moment I have just added a target to incrementally append bundles to the catalog, as probably rebuilding the whole catalog from scratch each time is too overkill. But the good thing is that having the bundle manifests of each operator version in this repo makes rebuilding the catalog possible if required.make

For example, to release marin3r's v0.7.0-alpha6 I issued the following command, which does the whole process in a single execution:

```bash
▶ make marin3r-catalog-add PROJECT_VERSION=v0.7.0-alpha6
```