### PR TITLE
Repository archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This repository has been archived in** https://github.com/3scale-ops/3scaleops-olm-catalog/pull/12
+
 # quay.io/3scaleops OLM catalog management
 
 ## Repo's directory structure


### PR DESCRIPTION
Repository has been archived because we no longer need to have those operators on a single centralized catalog. 

Right now each operator has its own CatalogSource managed by each repository Makefile.